### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y gcc python3 python3-pip git curl
+ARG bazelisk_version=1.16.0
+RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk_version}/bazelisk-linux-amd64 > /usr/bin/bazelisk && chmod +x /usr/bin/bazelisk && ln -s /usr/bin/bazelisk /usr/bin/bazel
+WORKDIR /gematria
+COPY . .
+RUN bazel run :requirements.update
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
This commit adds a Dockerfile to the repository containing all of the dependencies necessary to run/develop Gematria. We have found this pretty useful for the [ml-compiler-opt](https://github.com/google/ml-compileropt) repository as it allows for new users to quickly experiment without having to deal with "works on my machine errors" assuming they already have Docker somewhat integrated into their workflow (in addition to having some consumers using containers in production)

I typically use container based development workflows, and I think this might be helpful for others as well (hence why I've opened a PR) while also not adding much maintenance burden. If it's preferred that this isn't viewed as officially supported, we could do something similar to ml-compiler-opt where the `Dockerfile` is in an experimental folder with a note mentioning it is not officially supported.