### PR TITLE
Fix Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y gcc python3 python3-pip git curl
-ARG bazelisk_version=1.16.0
+RUN apt-get update && apt-get install -y clang python3 python3-pip git curl
+ARG bazelisk_version=1.17.0
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk_version}/bazelisk-linux-amd64 > /usr/bin/bazelisk && chmod +x /usr/bin/bazelisk && ln -s /usr/bin/bazelisk /usr/bin/bazel
 WORKDIR /gematria
 COPY . .


### PR DESCRIPTION
Without this patch, the docker build fails in something related to local_config_cc (not really fluent enough in bazel to know more than that it's local c/c++ toolchain related). Switching to clang fixes the issue. Not quite sure why that is (maybe some new project explicitly requests clang?)

This patch also updates Bazelisk in the container image to the latest release.