### PR TITLE
Remove requirements.txt file from repository

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-# Run `bazel run :requirements.update` to generate this file.


### PR DESCRIPTION
Having this file checked into the repository means that the ignore line in .gitignore is essentially nonfunctional. This patch removes requirements.txt so that the ignore line in .gitignore is functional and the generated requirements.txt doesn't accidentally end up in any commits.