### PR TITLE
Add in setup.py to create wheels for distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
 package(
     default_visibility = ["//visibility:private"],
 )
@@ -16,5 +18,17 @@ package_group(
     packages = [
         # Gematria code base.
         "//gematria/...",
+        "//tools/...",
     ],
 )
+
+# A target to create a copy of pybind11_abseil's status.so so that it can be
+# placed in the right path while building a pip package.
+copy_file(
+    name = "package_pybind11_abseil_status",
+    src = "@pybind11_abseil_repo//pybind11_abseil:status.so",
+    out = "pybind11_abseil/status.so",
+    visibility = ["//:internal_users"],
+)
+
+exports_files(["requirements.in"])

--- a/gematria/datasets/python/BUILD
+++ b/gematria/datasets/python/BUILD
@@ -18,6 +18,7 @@ gematria_pybind_extension(
         "//gematria/proto:canonicalized_instruction_py_pb2",
         "//gematria/proto:throughput_py_pb2",
     ],
+    visibility = ["//:internal_users"],
     deps = [
         "//gematria/basic_block:basic_block_protos",
         "//gematria/datasets:bhive_importer",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,45 @@
+load(
+    "//:python.bzl",
+    "gematria_py_binary",
+)
+
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+PACKAGE_SHARED_OBJECT_DEPS = [
+    "//gematria/llvm/python:canonicalizer.so",
+    "//gematria/llvm/python:llvm_architecture_support.so",
+    "//gematria/basic_block/python:basic_block_protos.so",
+    "//gematria/basic_block/python:basic_block.so",
+    "//gematria/datasets/python:bhive_importer.so",
+    "//gematria/granite/python:graph_builder.so",
+    "//gematria/model/python:oov_token_behavior.so",
+    # Use a custom target rather than the default external one for the pybind11 status
+    # shared object as the default target puts it in a place that setuptools doesn't
+    # understand.
+    "//:package_pybind11_abseil_status",
+]
+
+PACKAGE_PYTHON_DEPS = [
+    "//gematria/proto:basic_block_py_pb2",
+    "//gematria/proto:canonicalized_instruction_py_pb2",
+    "//gematria/proto:throughput_py_pb2",
+]
+
+genrule(
+    name = "shared_object_list",
+    srcs = PACKAGE_SHARED_OBJECT_DEPS,
+    outs = ["shared_object_list.txt"],
+    cmd = "echo {} > $@".format(" ".join(["$(rootpath {})".format(x) for x in PACKAGE_SHARED_OBJECT_DEPS])),
+)
+
+gematria_py_binary(
+    name = "build_pip_package",
+    srcs = ["build_pip_package.py"],
+    data = PACKAGE_SHARED_OBJECT_DEPS + PACKAGE_PYTHON_DEPS + [
+        "//:requirements.in",
+        "//tools:shared_object_list",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/build_pip_package.py
+++ b/tools/build_pip_package.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+import os
+import pkg_resources
+
+from setuptools import setup
+
+VERSION = '0.1.0.dev' + datetime.now(tz=timezone.utc).strftime('%Y%m%d%H%M')
+
+SHARED_OBJECT_MANIFEST_PATH = os.path.join(
+    os.path.dirname(__file__), 'shared_object_list.txt'
+)
+
+# Grab the shared objects from the manifest created by the Bazel //tools:shared_object_list target
+with open(SHARED_OBJECT_MANIFEST_PATH) as shared_object_manfiest:
+  shared_objects = shared_object_manfiest.read().strip().split(' ')
+
+requirements = []
+
+# Get the package dependencies from requirements.in
+with open('requirements.in') as requirements_file:
+  required_packages = [
+      str(requirement)
+      for requirement in pkg_resources.parse_requirements(requirements_file)
+  ]
+
+setup(
+    name='gematria',
+    version=VERSION,
+    description='Tooling for cost modelling',
+    author='Gematria Authors',
+    py_modules=[''],
+    install_requires=requirements,
+    packages=['', 'gematria.proto'],
+    package_data={'': shared_objects},
+    python_requires='>=3.10',
+)

--- a/tools/build_pip_package.py
+++ b/tools/build_pip_package.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """This module is used for building the Gematria python package. Usage:
 
-bazel run //tools:build_pip_package bdist_wheel
+bazel run //tools:build_pip_package -c opt -- bdist_wheel
 
 This will build a Gematria python wheel that can then be used as a normal
 python wheel.

--- a/tools/build_pip_package.py
+++ b/tools/build_pip_package.py
@@ -11,12 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""This module is used for building the Gematria python package. Usage:
+
+bazel run //tools:build_pip_package bdist_wheel
+
+This will build a Gematria python wheel that can then be used as a normal
+python wheel.
+"""
 
 from datetime import datetime, timezone
 import os
 import pkg_resources
 
 from setuptools import setup
+from setuptools import find_packages
 
 VERSION = '0.1.0.dev' + datetime.now(tz=timezone.utc).strftime('%Y%m%d%H%M')
 
@@ -42,9 +50,8 @@ setup(
     version=VERSION,
     description='Tooling for cost modelling',
     author='Gematria Authors',
-    py_modules=[''],
     install_requires=requirements,
-    packages=['', 'gematria.proto'],
+    packages=find_packages() + [''],
     package_data={'': shared_objects},
     python_requires='>=3.10',
 )


### PR DESCRIPTION
This patch adds in a setup.py file and associated bazel build rules to build python wheels that can be used for distribution on pypi. This is primarily aimed at making it easier to use Gematria tooling in other projects, particularly google/ml-compiler-opt.

This still needs a little bit of work (why it is marked as draft). I plan on making the dependencies on shared objects in the `setup.py` implicit since they're explicitly defined in Bazel and also fix up a couple remaining dependency issues within the bazel build. There are a couple hacky things that I am not a particular fan of such as the symlinking of the `pybind11_abseil/status.so` shared object to get it into a path that `setuptools` will take, but that can't be avoided with base `setuptools`. I still need to investigate if using custom commands will fix that issue.

I also still need to figure out versioning, probably just doing a commit commit hash/date with a nightly build instead of semantic versioning.

After this lands I plan on working on some CI infrastructure to automatically build wheels and push them to PyPI so that they can be used in other projects.