### PR TITLE
Add support for importing CSVs with differing formats

### DIFF
--- a/gematria/datasets/bhive_importer.cc
+++ b/gematria/datasets/bhive_importer.cc
@@ -110,7 +110,7 @@ absl::StatusOr<BasicBlockWithThroughputProto> BHiveImporter::ParseBHiveCsvLine(
   if (machine_code_hex_column_index == throughput_column_index) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "Expected machine code column and throughput column indices to be "
-        "different for `line`, but were both %d: %s",
+        "different, but were both %d: %s",
         machine_code_hex_column_index, line));
   }
   const std::string_view machine_code_hex =

--- a/gematria/datasets/bhive_importer.h
+++ b/gematria/datasets/bhive_importer.h
@@ -70,6 +70,7 @@ class BHiveImporter {
   // `base_address` as the address of the first instruction in the basic block.
   absl::StatusOr<BasicBlockWithThroughputProto> ParseBHiveCsvLine(
       std::string_view source_name, std::string_view line,
+      size_t machine_code_hex_column_index, size_t throughput_column_index,
       double throughput_scaling = 1.0, uint64_t base_address = 0);
 
  private:

--- a/gematria/datasets/python/bhive_importer.cc
+++ b/gematria/datasets/python/bhive_importer.cc
@@ -102,8 +102,8 @@ PYBIND11_MODULE(bhive_importer, m) {
       .def(  //
           "basic_block_with_throughput_proto_from_csv_line",
           &BHiveImporter::ParseBHiveCsvLine, py::arg("source_name"),
-          py::arg("line"), py::arg("machine_code_hex_column_index") = 0,
-          py::arg("throughput_column_index") = 1,
+          py::arg("line"), py::arg("machine_code_hex_column_index"),
+          py::arg("throughput_column_index"),
           py::arg("throughput_scaling") = 1.0,
           py::arg("base_address") = uint64_t{0},
           R"(Creates a BasicBlockWithThroughputProto from a BHive CSV line.
@@ -117,6 +117,10 @@ PYBIND11_MODULE(bhive_importer, m) {
             source_name: The name of the throughput source used in the output
               proto.
             line: The line from the BHive CSV file.
+            machine_code_hex_column_index: The index of the column in the CSV
+              containing the machine code in hex format.
+            throughput_column_index: The index of the column in the CSV
+              containing the throughput in cycles.
             throughput_scaling: An optional scaling applied to {throughput}.
             base_address: The address of the first instruction of the basic
               block.

--- a/gematria/datasets/python/bhive_importer.cc
+++ b/gematria/datasets/python/bhive_importer.cc
@@ -102,7 +102,9 @@ PYBIND11_MODULE(bhive_importer, m) {
       .def(  //
           "basic_block_with_throughput_proto_from_csv_line",
           &BHiveImporter::ParseBHiveCsvLine, py::arg("source_name"),
-          py::arg("line"), py::arg("throughput_scaling") = 1.0,
+          py::arg("line"), py::arg("machine_code_hex_column_index") = 0,
+          py::arg("throughput_column_index") = 1,
+          py::arg("throughput_scaling") = 1.0,
           py::arg("base_address") = uint64_t{0},
           R"(Creates a BasicBlockWithThroughputProto from a BHive CSV line.
 

--- a/gematria/datasets/python/bhive_importer_test.py
+++ b/gematria/datasets/python/bhive_importer_test.py
@@ -219,6 +219,31 @@ class BhiveImporterTest(absltest.TestCase):
         ),
     )
 
+  def test_x86_nonstandard_columns(self):
+    source_name = "test: made-up"
+    importer = bhive_importer.BHiveImporter(self._x86_canonicalizer)
+    # Same basic block as in test_x86_basic_block_proto_from_bytes().
+    block_proto = importer.basic_block_with_throughput_proto_from_csv_line(
+        source_name=source_name,
+        line="a,b,4829d38b44246c8b54246848c1fb034829d04839c3,10",
+        machine_code_hex_column_index=2,
+        throughput_column_index=3,
+        base_address=600,
+        throughput_scaling=2.0,
+    )
+    self.assertEqual(
+        block_proto,
+        throughput_pb2.BasicBlockWithThroughputProto(
+            basic_block=_EXPECTED_BASIC_BLOCK_PROTO,
+            inverse_throughputs=(
+                throughput_pb2.ThroughputWithSourceProto(
+                    source=source_name,
+                    inverse_throughput_cycles=[20.0],
+                ),
+            ),
+        ),
+    )
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/gematria/datasets/python/import_from_bhive.py
+++ b/gematria/datasets/python/import_from_bhive.py
@@ -77,13 +77,19 @@ _THROUGHPUT_COLUMN_INDEX = flags.DEFINE_integer(
     'The index of the throughput value column in the input CSV file.',
 )
 
-flags.register_multi_flags_validator(
+
+@flags.multi_flags_validator(
     ['machine_code_hex_column_index', 'throughput_column_index'],
-    lambda flags_dict: flags_dict['machine_code_hex_column_index']
-    != flags_dict['throughput_column_index'],
-    'Expected machine code column and throughput column indices to be'
-    ' different',
+    message=(
+        'Expected machine code column and throughput column indices to be'
+        ' different'
+    ),
 )
+def _validate_input_columns(flags_dict):
+  return (
+      flags_dict['machine_code_hex_column_index']
+      != flags_dict['throughput_column_index']
+  )
 
 
 def main(argv: Sequence[str]) -> None:

--- a/gematria/datasets/python/import_from_bhive.py
+++ b/gematria/datasets/python/import_from_bhive.py
@@ -66,6 +66,16 @@ _LLVM_TRIPLE = flags.DEFINE_string(
     'x86_64',
     'The LLVM triple used for disassembling the instructions in the data set.',
 )
+_MACHINE_CODE_HEX_COLUMN_INDEX = flags.DEFINE_integer(
+    'machine_code_hex_column_index',
+    '0',
+    'The index of the the machine code hex column in the input CSV file.',
+)
+_THROUGHPUT_COLUMN_INDEX = flags.DEFINE_integer(
+    'throughput_column_index',
+    '1',
+    'The index of the throughput value column in the input CSV file.',
+)
 
 
 def main(argv: Sequence[str]) -> None:
@@ -105,6 +115,8 @@ def main(argv: Sequence[str]) -> None:
         block_proto = importer.basic_block_with_throughput_proto_from_csv_line(
             source_name=_SOURCE_NAME.value,
             line=line,
+            machine_code_hex_column_index=_MACHINE_CODE_HEX_COLUMN_INDEX.value,
+            throughput_column_index=_THROUGHPUT_COLUMN_INDEX,
             throughput_scaling=_THROUGHPUT_SCALING.value,
         )
       except status.StatusNotOk:

--- a/gematria/datasets/python/import_from_bhive.py
+++ b/gematria/datasets/python/import_from_bhive.py
@@ -79,7 +79,7 @@ _THROUGHPUT_COLUMN_INDEX = flags.DEFINE_integer(
 
 
 @flags.multi_flags_validator(
-    ['machine_code_hex_column_index', 'throughput_column_index'],
+    [_MACHINE_CODE_HEX_COLUMN_INDEX.name, _THROUGHPUT_COLUMN_INDEX.name],
     message=(
         'Expected machine code column and throughput column indices to be'
         ' different'
@@ -87,8 +87,8 @@ _THROUGHPUT_COLUMN_INDEX = flags.DEFINE_integer(
 )
 def _validate_input_columns(flags_dict):
   return (
-      flags_dict['machine_code_hex_column_index']
-      != flags_dict['throughput_column_index']
+      flags_dict[_MACHINE_CODE_HEX_COLUMN_INDEX.name]
+      != flags_dict[_THROUGHPUT_COLUMN_INDEX.name]
   )
 
 

--- a/gematria/datasets/python/import_from_bhive.py
+++ b/gematria/datasets/python/import_from_bhive.py
@@ -77,6 +77,14 @@ _THROUGHPUT_COLUMN_INDEX = flags.DEFINE_integer(
     'The index of the throughput value column in the input CSV file.',
 )
 
+flags.register_multi_flags_validator(
+    ['machine_code_hex_column_index', 'throughput_column_index'],
+    lambda flags_dict: flags_dict['machine_code_hex_column_index']
+    != flags_dict['throughput_column_index'],
+    'Expected machine code column and throughput column indices to be'
+    ' different',
+)
+
 
 def main(argv: Sequence[str]) -> None:
   if len(argv) > 1:
@@ -116,7 +124,7 @@ def main(argv: Sequence[str]) -> None:
             source_name=_SOURCE_NAME.value,
             line=line,
             machine_code_hex_column_index=_MACHINE_CODE_HEX_COLUMN_INDEX.value,
-            throughput_column_index=_THROUGHPUT_COLUMN_INDEX,
+            throughput_column_index=_THROUGHPUT_COLUMN_INDEX.value,
             throughput_scaling=_THROUGHPUT_SCALING.value,
         )
       except status.StatusNotOk:


### PR DESCRIPTION
Other datasets such as Andreas Abel's uica-eval use slightly different CSV formats and there's no real reason not to support them since the only thing that differs is the column layout. This patch adds in two new flags that allow specifying the columns of the basic block hex and throughput data.

Should be mostly complete, but is in desperate need of formatting (which is why I've marked it as a draft).