### PR TITLE
Add tooling to create a compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # requirements.txt is built from requirements.in via
 # bazel run :requirements.update.
 /requirements.txt
+
+/compile_commands.json

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -65,3 +65,13 @@ To format the code, run:
 ```bash
 buildifier -r .
 ```
+
+## Developer tool support
+
+Most C++ IDE tooling such as clangd works with a compile_commands.json file. If
+your environment needs a compile_commands.json file, you can generate it using
+the following bazel invocation (after building the project):
+
+```bash
+bazel run @hedron_compile_commands//:refresh_all
+```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -172,3 +172,17 @@ http_archive(
         "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz",
     ],
 )
+
+# compile_commands.json extraction for clangd
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+
+http_archive(
+    name = "hedron_compile_commands",
+    sha256 = "3cd0e49f0f4a6d406c1d74b53b7616f5e24f5fd319eafc1bf8eee6e14124d115",
+    strip_prefix = "bazel-compile-commands-extractor-3dddf205a1f5cde20faf2444c1757abe0564ff4c",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/3dddf205a1f5cde20faf2444c1757abe0564ff4c.tar.gz",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()


### PR DESCRIPTION
As mentioned in the documentation this is necessary to use tooling like `clangd` in an IDE. I'm not sure what tooling was used internally to develop the project, but this seems to be fairly standard in other open source projects.