### PR TITLE
Add clang-format config and documentation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -30,3 +30,13 @@ All contributions must follow the Google's
 Contributions made by corporations are covered by a different agreement than
 the one above, the
 [Software Grant and Corporate Contributor License Agreement](https://cla.developers.google.com/about/google-corporate).
+
+## Code formatting
+
+All C++ code in this repository is formatted using `clang-format` in the Google
+style. Formatting a file can either be done by your IDE through `clangd`
+integration or manually by directly calling `clang-format`:
+
+```bash
+clang-format -i <path to .cc file>
+```


### PR DESCRIPTION
No changed files since these seems to be the format that was used internally. However, a config file still needs to be added as the default style for `clang-format` isn't `Google`, and it's good to have some documentation on how to use the formatting tools.