### PR TITLE
Add formatting jobs to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Gematria CI
+
+on: [push, repository_dispatch, pull_request]
+
+jobs:
+  check-python-formatting:
+    name: Python Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install pyink
+        run: pip3 install pyink==23.5.0
+      - name: Check python formatting
+        run: pyink --check --diff .
+  check-cpp-formatting:
+    name: C++ Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check c++ formatting
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '16'
+        check-path: 'src'
+  check-bazel-formatting:
+    name: Bazel Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: thompsonja/bazel-buildifier@v0.4.0
+      with:
+        buildifier_version: v6.1.2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,7 @@ git_repository(
 
 # Python
 load("@upb//bazel:system_python.bzl", "system_python")
+
 system_python(
     name = "system_python",
     minimum_python_version = "3.10",


### PR DESCRIPTION
As a public repository, Gematria gets unlimited free minutes for running jobs on Github CI. We've had good success using Github actions to ensure code is formatted properly/tests pass in MLGO, so I'm opening up this patch to do the same with Gematria so that it's less likely developers miss something.

Note that I'm using external dependencies here to make the setup easier, which may not be super desirable due to issues like maintenance concerns, but migrating off of them should be trivial. Something to note, however.