### PR TITLE
Update Dockerfile after dependency installation change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ ARG bazelisk_version=1.17.0
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk_version}/bazelisk-linux-amd64 > /usr/bin/bazelisk && chmod +x /usr/bin/bazelisk && ln -s /usr/bin/bazelisk /usr/bin/bazel
 WORKDIR /gematria
 COPY . .
-RUN bazel run :requirements.update
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.in
+


### PR DESCRIPTION
Recently we moved from declaring an entire transitive closure in requirements.txt (and generating that with Bazel) to declaring just the top-level packages along with version information in requirements.in. This change brought with it a different set of commands for setup which breaks the existing Dockerfile. This patch fixes the Dockerfile to match the new setup.