### PR TITLE
Update documentation to correct config options for benchmarks

### DIFF
--- a/gematria/experiments/access_pattern_bm/README.md
+++ b/gematria/experiments/access_pattern_bm/README.md
@@ -7,12 +7,12 @@ basic blocks and functions augmented with cache hit and miss ratios.
 
 The benchmarks can be built using
 ```bash
-bazel build -c opt --define pfm=true //gematria/experiments/access_pattern_bm/...
+bazel build -c opt --define pfm=1 //gematria/experiments/access_pattern_bm/...
 ```
 or, if timing measurements between flushing and non-flushing benchmarks are to 
 be compared, using
 ```bash
-bazel build -c opt --define pfm=true --define balance_flushing_time=true //gematria/experiments/access_pattern_bm/...
+bazel build -c opt --define pfm=1 --define balance_flushing_time=true //gematria/experiments/access_pattern_bm/...
 ```
 and built binaries for each benchmark can be found down the corresponding 
 path in `bazel-bin`.


### PR DESCRIPTION
Currently the documentation shows setting --pfm=true to get access to performance counters in the access pattern benchmarks, but Google benchmark only recognizes --pfm=1. This patch corrects the documentation for this.