### PR TITLE
Fix C++ Formatting with clang-format

### DIFF
--- a/gematria/llvm/canonicalizer.cc
+++ b/gematria/llvm/canonicalizer.cc
@@ -19,6 +19,7 @@
 #include <string_view>
 
 #include "gematria/basic_block/basic_block.h"
+#include "lib/Target/X86/MCTargetDesc/X86BaseInfo.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCInst.h"
@@ -28,7 +29,6 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Target/TargetMachine.h"
-#include "lib/Target/X86/MCTargetDesc/X86BaseInfo.h"
 
 namespace gematria {
 namespace {


### PR DESCRIPTION
This patch fixes the C++ formatting which was causing the clang-format job to fail. Very minor change, but if we're going to have C++ formatting in CI, we should probably keep it green.