### PR TITLE
Reformat bazel files with buildifier

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -177,29 +177,31 @@ http_archive(
     urls = ["https://github.com/llvm/llvm-project/archive/{commit}.zip".format(commit = LLVM_COMMIT)],
 )
 
-load("@llvm-raw//utils/bazel:configure.bzl",
- "llvm_configure")
+load(
+    "@llvm-raw//utils/bazel:configure.bzl",
+    "llvm_configure",
+)
 
 llvm_configure(name = "llvm-project")
 
 http_archive(
-  name = "llvm_zlib",
-  build_file = "@llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
-  sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
-  strip_prefix = "zlib-ng-2.0.7",
-  urls = [
-      "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
-  ],
+    name = "llvm_zlib",
+    build_file = "@llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
+    sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
+    strip_prefix = "zlib-ng-2.0.7",
+    urls = [
+        "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
+    ],
 )
 
 http_archive(
-  name = "llvm_zstd",
-  build_file = "@llvm-raw//utils/bazel/third_party_build:zstd.BUILD",
-  sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
-  strip_prefix = "zstd-1.5.2",
-  urls = [
-      "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
-  ],
+    name = "llvm_zstd",
+    build_file = "@llvm-raw//utils/bazel/third_party_build:zstd.BUILD",
+    sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
+    strip_prefix = "zstd-1.5.2",
+    urls = [
+        "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz",
+    ],
 )
 
 # compile_commands.json extraction for clangd


### PR DESCRIPTION
The bazel files were also changed after the recent push and no longer are formatted correctly according to buildifier. This patch does the necessary reformatting.