### PR TITLE
Mark the cache/perf counter experiments as x86-64 only.

### DIFF
--- a/gematria/experiments/access_pattern_bm/BUILD
+++ b/gematria/experiments/access_pattern_bm/BUILD
@@ -29,6 +29,7 @@ cc_library(
     copts = FEATURE_OPTS,
     target_compatible_with = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
 )
 
@@ -54,6 +55,7 @@ cc_library(
     copts = FEATURE_OPTS,
     target_compatible_with = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     deps = ["@com_google_absl//absl/base:core_headers"],
 )
@@ -80,6 +82,7 @@ cc_library(
     copts = FEATURE_OPTS,
     target_compatible_with = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     deps = ["@com_google_absl//absl/base:core_headers"],
 )
@@ -110,6 +113,7 @@ cc_test(
     copts = BALANCE_FLUSHING_TIME_OPTS + FEATURE_OPTS,  # Since templated functions using _mm_clflushopt are defined in the header.
     target_compatible_with = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     deps = [
         "@com_github_google_benchmark//:benchmark_main",
@@ -127,6 +131,7 @@ cc_test(
     copts = BALANCE_FLUSHING_TIME_OPTS + FEATURE_OPTS,  # Since templated functions using _mm_clflushopt are defined in the header.
     target_compatible_with = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     deps = [
         "@com_github_google_benchmark//:benchmark_main",

--- a/gematria/experiments/access_pattern_bm/BUILD
+++ b/gematria/experiments/access_pattern_bm/BUILD
@@ -27,6 +27,9 @@ cc_library(
     srcs = ["linked_list.cc"],
     hdrs = ["linked_list.h"],
     copts = FEATURE_OPTS,
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 cc_test(
@@ -49,6 +52,9 @@ cc_library(
     srcs = ["contiguous_matrix.cc"],
     hdrs = ["contiguous_matrix.h"],
     copts = FEATURE_OPTS,
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     deps = ["@com_google_absl//absl/base:core_headers"],
 )
 
@@ -72,6 +78,9 @@ cc_library(
     srcs = ["vec_of_vec_matrix.cc"],
     hdrs = ["vec_of_vec_matrix.h"],
     copts = FEATURE_OPTS,
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     deps = ["@com_google_absl//absl/base:core_headers"],
 )
 
@@ -99,6 +108,9 @@ cc_test(
         "stl_container_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS + FEATURE_OPTS,  # Since templated functions using _mm_clflushopt are defined in the header.
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     deps = [
         "@com_github_google_benchmark//:benchmark_main",
     ],
@@ -113,6 +125,9 @@ cc_test(
         "stl_assoc_container_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS + FEATURE_OPTS,  # Since templated functions using _mm_clflushopt are defined in the header.
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     deps = [
         "@com_github_google_benchmark//:benchmark_main",
     ],


### PR DESCRIPTION
The experimental code depends on x86-64 specific intrinsics, and breaks the build on Apple silicon and other non-x86 platforms.