### PR TITLE
Only run push CI on main branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,12 @@
 
 name: Gematria CI
 
-on: [push, repository_dispatch, pull_request]
+on:
+  push:
+    branches:
+      - main
+  repository_dispatch:
+  pull_request:
 
 jobs:
   check-python-formatting:


### PR DESCRIPTION
Currently the github actions workflow runs whenever something is pushed to a branch or against any pull request. This means that if a branch is pushed to the main google/gematria repository and a PR is opened against google/gematria:main, there will be duplicate jobs, one for the push event and one for the pull request event. This patch fixes this behavior by restricting the push event to the main branch.