### PR TITLE
Fix python formatting CI job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install pyink
-        run: pip3 install pyink==23.5.0
+        run: pip3 install pyink==23.9.1
       - name: Check python formatting
         run: pyink --check --diff .
   check-cpp-formatting:


### PR DESCRIPTION
For some reason, using an older version of pyink causes odd failures in the CI complaining about missing functions in a vendored dependency. Upgrading to the most recent version fixes the issue. Maybe should try and make this more hermetic at some point with a lockfile or something, but for now this is a simple fix.