### PR TITLE
Clang-format some files

### DIFF
--- a/gematria/llvm/asm_parser_test.cc
+++ b/gematria/llvm/asm_parser_test.cc
@@ -25,10 +25,10 @@
 #include "gematria/testing/matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "llvm/IR/InlineAsm.h"
-#include "llvm/MC/MCInst.h"
 #include "lib/Target/X86/MCTargetDesc/X86BaseInfo.h"  //// IWYU pragma: keep (for opcodes).
 #include "lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/MC/MCInst.h"
 
 namespace gematria {
 namespace {

--- a/gematria/testing/llvm_test.cc
+++ b/gematria/testing/llvm_test.cc
@@ -16,9 +16,9 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstBuilder.h"
-#include "lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 
 namespace gematria {
 namespace {


### PR DESCRIPTION
The previous commit reworked all of the llvm includes, but broke the code formatting job in the meantime. This patch fixes the code formatting to get the CI back to green.