### PR TITLE
Add exegesis BB annotator

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,9 +165,9 @@ new_git_repository(
 
 # LLVM and its dependencies
 
-LLVM_COMMIT = "8d300e67d2227f55fc5056cd3eec8c62d084c1b9"
+LLVM_COMMIT = "67d7903262ce5c35bb23d599040dff29b9d7759e"
 
-LLVM_SHA256 = "bc92b042ca833514311b273a2422259950ed7069b6a06f85833253f0ac1b5221"
+LLVM_SHA256 = "0282bcfc2a66e9c499dd0464c636225318b3b20ebc7e497e0bf845809d8f3b6a"
 
 http_archive(
     name = "llvm-raw",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,14 +165,14 @@ new_git_repository(
 
 # LLVM and its dependencies
 
-# TODO(boomanaiden154): Go back to proper upstream commit once the appropriate
-# patches land there.
+LLVM_COMMIT = "8d300e67d2227f55fc5056cd3eec8c62d084c1b9"
 
-LLVM_COMMIT = "f13b5d31450a095d6e11176b3db787f1e0894337"
+LLVM_SHA256 = "bc92b042ca833514311b273a2422259950ed7069b6a06f85833253f0ac1b5221"
 
 http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
+    sha256 = LLVM_SHA256,
     strip_prefix = "llvm-project-" + LLVM_COMMIT,
     urls = ["https://github.com/llvm/llvm-project/archive/{commit}.zip".format(commit = LLVM_COMMIT)],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,14 +165,14 @@ new_git_repository(
 
 # LLVM and its dependencies
 
-LLVM_COMMIT = "2a1f1b5fde0a2e03f94fa2cb5c7765d405fda0de"
+# TODO(boomanaiden154): Go back to proper upstream commit once the appropriate
+# patches land there.
 
-LLVM_SHA256 = "f91c596575c69d9861892fdf57ad54d1fb31ab1a4eb5897f3bd58383ed69f838"
+LLVM_COMMIT = "f13b5d31450a095d6e11176b3db787f1e0894337"
 
 http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
-    sha256 = LLVM_SHA256,
     strip_prefix = "llvm-project-" + LLVM_COMMIT,
     urls = ["https://github.com/llvm/llvm-project/archive/{commit}.zip".format(commit = LLVM_COMMIT)],
 )

--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -72,6 +72,19 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "find_accessed_addrs_exegesis",
+    srcs = ["find_accessed_addrs_exegesis.cc"],
+    hdrs = ["find_accessed_addrs_exegesis.h"],
+    deps = [
+        "@llvm-project//llvm:Exegesis",
+        "@llvm-project//llvm:Support",
+        ":find_accessed_addrs",
+        "//gematria/llvm:llvm_architecture_support",
+        "//gematria/llvm:disassembler",
+    ],
+)
+
 cc_test(
     name = "find_accessed_addrs_test",
     srcs = ["find_accessed_addrs_test.cc"],
@@ -85,6 +98,7 @@ cc_test(
     ],
     deps = [
         ":find_accessed_addrs",
+        ":find_accessed_addrs_exegesis",
         "//gematria/llvm:asm_parser",
         "//gematria/llvm:llvm_architecture_support",
         "//gematria/testing:matchers",

--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -77,11 +77,11 @@ cc_library(
     srcs = ["find_accessed_addrs_exegesis.cc"],
     hdrs = ["find_accessed_addrs_exegesis.h"],
     deps = [
+        ":find_accessed_addrs",
+        "//gematria/llvm:disassembler",
+        "//gematria/llvm:llvm_architecture_support",
         "@llvm-project//llvm:Exegesis",
         "@llvm-project//llvm:Support",
-        ":find_accessed_addrs",
-        "//gematria/llvm:llvm_architecture_support",
-        "//gematria/llvm:disassembler",
     ],
 )
 

--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -98,7 +98,6 @@ cc_test(
     ],
     deps = [
         ":find_accessed_addrs",
-        ":find_accessed_addrs_exegesis",
         "//gematria/llvm:asm_parser",
         "//gematria/llvm:llvm_architecture_support",
         "//gematria/testing:matchers",
@@ -114,6 +113,25 @@ cc_test(
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
         "@llvm-project//llvm:ir_headers",
+    ],
+)
+
+cc_test(
+    name = "find_accessed_addrs_exegesis_test",
+    srcs = ["find_accessed_addrs_exegesis_test.cc"],
+    # The llvm-exegesis features used in the exegesis snippet annotator and thus
+    # the tests are currently only supported on X86_64.
+    tags = [
+        "not_build:arm",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
+    deps = [
+        ":find_accessed_addrs_exegesis",
+        "//gematria/llvm:asm_parser",
+        "@com_google_absl//absl/log:check",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -14,14 +14,18 @@
 
 #include "gematria/datasets/find_accessed_addrs_exegesis.h"
 
-#include "BenchmarkRunner.h"
-#include "LlvmState.h"
-#include "Target.h"
-#include "TargetSelect.h"
+// Use the absolute path for headers from llvm-exegesis as there is no
+// canonical include path within LLVM as they are not properly exposed through
+// a library and could potentially be confused with other LLVM includes.
+
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86RegisterInfo.h"
 #include "gematria/llvm/disassembler.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
+#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
+#include "llvm/tools/llvm-exegesis/lib/Target.h"
+#include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 
 using namespace llvm;
 using namespace llvm::exegesis;

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -1,0 +1,152 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/find_accessed_addrs_exegesis.h"
+
+#include "BenchmarkRunner.h"
+#include "LlvmState.h"
+#include "Target.h"
+#include "TargetSelect.h"
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86RegisterInfo.h"
+#include "gematria/llvm/disassembler.h"
+
+using namespace llvm;
+using namespace llvm::exegesis;
+
+namespace gematria {
+
+ExegesisAnnotator::ExegesisAnnotator(
+    LlvmArchitectureSupport &ArchSupport_, LLVMState &State_,
+    std::unique_ptr<BenchmarkRunner> Runner_,
+    std::unique_ptr<const SnippetRepetitor> Repetitor_)
+    : ArchSupport(ArchSupport_),
+      MCPrinter(ArchSupport.CreateMCInstPrinter(0)),
+      State(State_),
+      Runner(std::move(Runner_)),
+      Repetitor(std::move(Repetitor_)) {}
+
+Expected<std::unique_ptr<ExegesisAnnotator>> ExegesisAnnotator::Create(
+    LlvmArchitectureSupport &ArchSupport_, LLVMState &State_) {
+  // Initialize the supported Exegesis targets. Currently we only support X86.
+  InitializeX86ExegesisTarget();
+
+  if (pfm::pfmInitialize())
+    return make_error<StringError>(
+        "Failed to initialize libpfm",
+        std::make_error_code(std::errc::invalid_argument));
+
+  auto RunnerOrErr = State_.getExegesisTarget().createBenchmarkRunner(
+      Benchmark::Latency, State_, BenchmarkPhaseSelectorE::Measure,
+      BenchmarkRunner::ExecutionModeE::SubProcess, Benchmark::Min);
+
+  if (!RunnerOrErr) return RunnerOrErr.takeError();
+
+  std::unique_ptr<const SnippetRepetitor> Repetitor_ =
+      SnippetRepetitor::Create(Benchmark::RepetitionModeE::Duplicate, State_);
+
+  return std::unique_ptr<ExegesisAnnotator>(new ExegesisAnnotator(
+      ArchSupport_, State_, std::move(*RunnerOrErr), std::move(Repetitor_)));
+}
+
+Expected<AccessedAddrs> ExegesisAnnotator::FindAccessedAddrs(
+    ArrayRef<uint8_t> BasicBlock) {
+  Expected<std::vector<DisassembledInstruction>> DisInstructions =
+      DisassembleAllInstructions(
+          ArchSupport.mc_disassembler(), ArchSupport.mc_instr_info(),
+          ArchSupport.mc_register_info(), ArchSupport.mc_subtarget_info(),
+          *MCPrinter, 0, BasicBlock);
+
+  if (!DisInstructions) return DisInstructions.takeError();
+
+  std::vector<MCInst> Instructions;
+  Instructions.reserve(DisInstructions->size());
+
+  for (const auto &DisInstruction : *DisInstructions)
+    Instructions.push_back(DisInstruction.mc_inst);
+
+  AccessedAddrs MemAnnotations;
+  MemAnnotations.code_location = 0;
+  MemAnnotations.block_size = 4096;
+
+  BenchmarkCode BenchCode;
+  BenchCode.Key.Instructions = Instructions;
+
+  MemoryValue MemVal;
+  MemVal.Value = APInt(4096, 0x0000000012345600);
+  MemVal.Index = 0;
+  MemVal.SizeBytes = 4096;
+
+  BenchCode.Key.MemoryValues["memdef1"] = MemVal;
+
+  const llvm::MCRegisterInfo &MRI = ArchSupport.mc_register_info();
+
+  for (unsigned i = 0;
+       i < MRI.getRegClass(X86::GR64_NOREX2RegClassID).getNumRegs(); ++i) {
+    RegisterValue RegVal;
+    RegVal.Register =
+        MRI.getRegClass(X86::GR64_NOREX2RegClassID).getRegister(i);
+    RegVal.Value = APInt(64, 0x12345600);
+    BenchCode.Key.RegisterInitialValues.push_back(RegVal);
+  }
+
+  for (unsigned i = 0; i < MRI.getRegClass(X86::VR128RegClassID).getNumRegs();
+       ++i) {
+    RegisterValue RegVal;
+    RegVal.Register = MRI.getRegClass(X86::VR128RegClassID).getRegister(i);
+    RegVal.Value = APInt(128, 0x12345600);
+    BenchCode.Key.RegisterInitialValues.push_back(RegVal);
+  }
+
+  while (true) {
+    std::unique_ptr<const SnippetRepetitor> SR =
+        SnippetRepetitor::Create(Benchmark::RepetitionModeE::Duplicate, State);
+    Expected<BenchmarkRunner::RunnableConfiguration> RCOrErr =
+        Runner->getRunnableConfiguration(BenchCode, 10000, 0, *SR);
+
+    if (!RCOrErr) return RCOrErr.takeError();
+
+    BenchmarkRunner::RunnableConfiguration &RC = *RCOrErr;
+
+    auto BenchmarkResults = Runner->runConfiguration(std::move(RC), {}, true);
+
+    // If we don't have any errors executing the snippet, we executed the
+    // snippet successfully and thus have all the needed memory annotations.
+    if (BenchmarkResults) break;
+
+    auto ResultError = BenchmarkResults.takeError();
+
+    if (!ResultError.isA<SnippetCrash>()) return std::move(ResultError);
+
+    handleAllErrors(std::move(ResultError), [&](SnippetCrash &CrashInfo) {
+      if (CrashInfo.GetCrashAddress() == 0) return;
+
+      MemoryMapping MemMap;
+      MemMap.Address = CrashInfo.GetCrashAddress();
+      MemMap.MemoryValueName = "memdef1";
+      BenchCode.Key.MemoryMappings.push_back(MemMap);
+    });
+  }
+
+  MemAnnotations.accessed_blocks.reserve(BenchCode.Key.MemoryMappings.size());
+
+  for (const MemoryMapping &Mapping : BenchCode.Key.MemoryMappings) {
+    MemAnnotations.accessed_blocks.push_back(Mapping.Address);
+  }
+
+  return MemAnnotations;
+}
+
+}  // namespace gematria

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -85,7 +85,7 @@ Expected<AccessedAddrs> ExegesisAnnotator::FindAccessedAddrs(
   BenchCode.Key.Instructions = Instructions;
 
   MemoryValue MemVal;
-  MemVal.Value = APInt(4096, 0x0000000012345600);
+  MemVal.Value = APInt(64, 0x12345600);
   MemVal.Index = 0;
   MemVal.SizeBytes = 4096;
 

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -132,8 +132,6 @@ Expected<AccessedAddrs> ExegesisAnnotator::FindAccessedAddrs(
 
     handleAllErrors(std::move(std::get<0>(BenchmarkResultOrErr)),
                     [&](SnippetSegmentationFault &CrashInfo) {
-                      if (CrashInfo.getAddress() == 0) return;
-
                       MemoryMapping MemMap;
                       MemMap.Address = CrashInfo.getAddress();
                       MemMap.MemoryValueName = "memdef1";

--- a/gematria/datasets/find_accessed_addrs_exegesis.h
+++ b/gematria/datasets/find_accessed_addrs_exegesis.h
@@ -1,0 +1,51 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMATRIA_DATASETS_FIND_ACCESSED_ADDRS_EXEGESIS_H_
+#define GEMATRIA_DATASETS_FIND_ACCESSED_ADDRS_EXEGESIS_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "BenchmarkRunner.h"
+#include "LlvmState.h"
+#include "gematria/datasets/find_accessed_addrs.h"
+#include "gematria/llvm/llvm_architecture_support.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace gematria {
+
+class ExegesisAnnotator {
+  LlvmArchitectureSupport &ArchSupport;
+  std::unique_ptr<llvm::MCInstPrinter> MCPrinter;
+
+  llvm::exegesis::LLVMState &State;
+  std::unique_ptr<llvm::exegesis::BenchmarkRunner> Runner;
+  std::unique_ptr<const llvm::exegesis::SnippetRepetitor> Repetitor;
+
+  ExegesisAnnotator(
+      LlvmArchitectureSupport &ArchSupport_, llvm::exegesis::LLVMState &State_,
+      std::unique_ptr<llvm::exegesis::BenchmarkRunner> Runner_,
+      std::unique_ptr<const llvm::exegesis::SnippetRepetitor> Repetitor_);
+
+ public:
+  static llvm::Expected<std::unique_ptr<ExegesisAnnotator>> Create(
+      LlvmArchitectureSupport &ArchSupport_, llvm::exegesis::LLVMState &State_);
+  llvm::Expected<AccessedAddrs> FindAccessedAddrs(
+      llvm::ArrayRef<uint8_t> BasicBlock);
+};
+
+}  // namespace gematria
+
+#endif  // GEMATRIA_DATASETS_FIND_ACCESSED_ADDRS_EXEGESIS_H_

--- a/gematria/datasets/find_accessed_addrs_exegesis.h
+++ b/gematria/datasets/find_accessed_addrs_exegesis.h
@@ -34,20 +34,21 @@ using namespace llvm::exegesis;
 namespace gematria {
 
 class ExegesisAnnotator {
-  LlvmArchitectureSupport &ArchSupport;
-  std::unique_ptr<MCInstPrinter> MCPrinter;
+  std::unique_ptr<MCInstPrinter> MachinePrinter;
+  std::unique_ptr<MCContext> MachineContext;
+  std::unique_ptr<MCDisassembler> MachineDisassembler;
 
   LLVMState &State;
   std::unique_ptr<BenchmarkRunner> Runner;
   std::unique_ptr<const SnippetRepetitor> Repetitor;
 
-  ExegesisAnnotator(LlvmArchitectureSupport &ArchSup, LLVMState &ExegesisState,
+  ExegesisAnnotator(LLVMState &ExegesisState,
                     std::unique_ptr<BenchmarkRunner> BenchRunner,
                     std::unique_ptr<const SnippetRepetitor> SnipRepetitor);
 
  public:
   static Expected<std::unique_ptr<ExegesisAnnotator>> create(
-      LlvmArchitectureSupport &ArchSup, LLVMState &ExegesisState);
+      LLVMState &ExegesisState);
   Expected<AccessedAddrs> findAccessedAddrs(ArrayRef<uint8_t> BasicBlock);
 };
 

--- a/gematria/datasets/find_accessed_addrs_exegesis.h
+++ b/gematria/datasets/find_accessed_addrs_exegesis.h
@@ -18,11 +18,15 @@
 #include <cstdint>
 #include <vector>
 
-#include "BenchmarkRunner.h"
-#include "LlvmState.h"
+// Use the absolute path for headers from llvm-exegesis as there is no
+// canonical include path within LLVM as they are not properly exposed through
+// a library and could potentially be confused with other LLVM includes.
+
 #include "gematria/datasets/find_accessed_addrs.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
+#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
 
 using namespace llvm;
 using namespace llvm::exegesis;

--- a/gematria/datasets/find_accessed_addrs_exegesis.h
+++ b/gematria/datasets/find_accessed_addrs_exegesis.h
@@ -24,26 +24,27 @@
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "llvm/ADT/ArrayRef.h"
 
+using namespace llvm;
+using namespace llvm::exegesis;
+
 namespace gematria {
 
 class ExegesisAnnotator {
   LlvmArchitectureSupport &ArchSupport;
-  std::unique_ptr<llvm::MCInstPrinter> MCPrinter;
+  std::unique_ptr<MCInstPrinter> MCPrinter;
 
-  llvm::exegesis::LLVMState &State;
-  std::unique_ptr<llvm::exegesis::BenchmarkRunner> Runner;
-  std::unique_ptr<const llvm::exegesis::SnippetRepetitor> Repetitor;
+  LLVMState &State;
+  std::unique_ptr<BenchmarkRunner> Runner;
+  std::unique_ptr<const SnippetRepetitor> Repetitor;
 
-  ExegesisAnnotator(
-      LlvmArchitectureSupport &ArchSupport_, llvm::exegesis::LLVMState &State_,
-      std::unique_ptr<llvm::exegesis::BenchmarkRunner> Runner_,
-      std::unique_ptr<const llvm::exegesis::SnippetRepetitor> Repetitor_);
+  ExegesisAnnotator(LlvmArchitectureSupport &ArchSup, LLVMState &ExegesisState,
+                    std::unique_ptr<BenchmarkRunner> BenchRunner,
+                    std::unique_ptr<const SnippetRepetitor> SnipRepetitor);
 
  public:
-  static llvm::Expected<std::unique_ptr<ExegesisAnnotator>> Create(
-      LlvmArchitectureSupport &ArchSupport_, llvm::exegesis::LLVMState &State_);
-  llvm::Expected<AccessedAddrs> FindAccessedAddrs(
-      llvm::ArrayRef<uint8_t> BasicBlock);
+  static Expected<std::unique_ptr<ExegesisAnnotator>> create(
+      LlvmArchitectureSupport &ArchSup, LLVMState &ExegesisState);
+  Expected<AccessedAddrs> findAccessedAddrs(ArrayRef<uint8_t> BasicBlock);
 };
 
 }  // namespace gematria

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -14,13 +14,16 @@
 
 #include "gematria/datasets/find_accessed_addrs_exegesis.h"
 
-#include "TargetSelect.h"
+// Use the absolute path for headers from llvm-exegesis as there is no
+// canonical include path within LLVM as they are not properly exposed through
+// a library and could potentially be confused with other LLVM includes.
+
 #include "absl/log/check.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gtest/gtest.h"
 #include "llvm/MC/MCCodeEmitter.h"
-// #include "llvm/Testing/Support/Error.h"
+#include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 
 using namespace llvm;
 using namespace llvm::exegesis;

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -72,8 +72,7 @@ class FindAccessedAddrsExegesisTest : public testing::Test {
   llvm::Expected<AccessedAddrs> FindAccessedAddrsExegesis(
       std::string_view TextualAssembly) {
     auto Code = Assemble(TextualAssembly);
-    auto Annotator =
-        cantFail(ExegesisAnnotator::create(*LLVMArchSupport, State));
+    auto Annotator = cantFail(ExegesisAnnotator::create(State));
     return Annotator->findAccessedAddrs(llvm::ArrayRef(
         reinterpret_cast<const uint8_t*>(Code.data()), Code.size()));
   }

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/find_accessed_addrs_exegesis.h"
+
+#include "TargetSelect.h"
+#include "absl/log/check.h"
+#include "gematria/llvm/asm_parser.h"
+#include "gematria/llvm/llvm_architecture_support.h"
+#include "gtest/gtest.h"
+#include "llvm/MC/MCCodeEmitter.h"
+// #include "llvm/Testing/Support/Error.h"
+
+using namespace llvm;
+using namespace llvm::exegesis;
+
+namespace gematria {
+namespace {
+
+class FindAccessedAddrsExegesisTest : public testing::Test {
+ private:
+  inline static std::unique_ptr<LlvmArchitectureSupport> LLVMArchSupport;
+  LLVMState State;
+
+ protected:
+  FindAccessedAddrsExegesisTest()
+      : State(cantFail(llvm::exegesis::LLVMState::Create("", "native"))) {}
+
+  static void SetUpTestSuite() {
+    LLVMArchSupport = LlvmArchitectureSupport::X86_64();
+    InitializeX86ExegesisTarget();
+  }
+
+  std::string Assemble(std::string_view TextualAssembly) {
+    auto MCInstsOrErr = gematria::ParseAsmCodeFromString(
+        LLVMArchSupport->target_machine(), TextualAssembly,
+        InlineAsm::AsmDialect::AD_ATT);
+    CHECK_OK(MCInstsOrErr);
+    const auto& MachineInstructions = *MCInstsOrErr;
+
+    MCContext MachineCodeContext(
+        LLVMArchSupport->target_machine().getTargetTriple(),
+        &LLVMArchSupport->mc_asm_info(), &LLVMArchSupport->mc_register_info(),
+        &LLVMArchSupport->mc_subtarget_info());
+    const auto CodeEmitter =
+        absl::WrapUnique(LLVMArchSupport->target().createMCCodeEmitter(
+            LLVMArchSupport->mc_instr_info(), MachineCodeContext));
+
+    SmallString<128> Code;
+    SmallVector<MCFixup> Fixups;
+    for (const auto& MachineInstruction : MachineInstructions)
+      CodeEmitter->encodeInstruction(MachineInstruction, Code, Fixups,
+                                     LLVMArchSupport->mc_subtarget_info());
+
+    return std::string(Code);
+  }
+
+  llvm::Expected<AccessedAddrs> FindAccessedAddrsExegesis(
+      std::string_view TextualAssembly) {
+    auto Code = Assemble(TextualAssembly);
+    auto Annotator =
+        cantFail(ExegesisAnnotator::create(*LLVMArchSupport, State));
+    return Annotator->findAccessedAddrs(llvm::ArrayRef(
+        reinterpret_cast<const uint8_t*>(Code.data()), Code.size()));
+  }
+};
+
+// TODO(boomanaiden154): The boolean static casting to check the status of the
+// Expecteds in the following two test cases can be replaced with
+// ASSERT_THAT_EXPECTED once pthread errors that occur when linking
+// llvm:TestingSupport are fixed.
+TEST_F(FindAccessedAddrsExegesisTest, ExegesisNoAccess) {
+  auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
+    movq %r11, %r12
+  )asm");
+  ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
+  AccessedAddrs Result = *AddrsOrErr;
+  EXPECT_EQ(Result.accessed_blocks.size(), 0);
+}
+
+TEST_F(FindAccessedAddrsExegesisTest, ExegesisOneAccess) {
+  auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
+    movq $0x10000, %rax
+    movq (%rax), %rax
+  )asm");
+  ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
+  AccessedAddrs Result = *AddrsOrErr;
+  EXPECT_EQ(Result.accessed_blocks.size(), 1);
+  EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
+}
+
+}  // namespace
+}  // namespace gematria

--- a/gematria/datasets/find_accessed_addrs_test.cc
+++ b/gematria/datasets/find_accessed_addrs_test.cc
@@ -16,10 +16,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <string_view>
 
+#include "TargetSelect.h"
 #include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/random/distributions.h"
@@ -27,11 +29,13 @@
 #include "absl/random/seed_sequences.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
+#include "gematria/datasets/find_accessed_addrs_exegesis.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/testing/matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -54,10 +58,15 @@ uintptr_t AlignDown(uintptr_t x, size_t align) { return x - (x % align); }
 class FindAccessedAddrsTest : public testing::Test {
  private:
   inline static std::unique_ptr<LlvmArchitectureSupport> llvm_arch_support_;
+  llvm::exegesis::LLVMState state;
 
  protected:
+  FindAccessedAddrsTest()
+      : state(cantFail(llvm::exegesis::LLVMState::Create("", "native"))) {}
+
   static void SetUpTestSuite() {
     llvm_arch_support_ = LlvmArchitectureSupport::X86_64();
+    llvm::exegesis::InitializeX86ExegesisTarget();
   }
 
   std::string Assemble(std::string_view textual_assembly) {
@@ -92,6 +101,15 @@ class FindAccessedAddrsTest : public testing::Test {
     auto span = absl::MakeConstSpan(
         reinterpret_cast<const uint8_t*>(code.data()), code.size());
     return FindAccessedAddrs(span);
+  }
+
+  llvm::Expected<AccessedAddrs> FindAccessedAddrsExegesis(
+      std::string_view textual_assembly) {
+    auto code = Assemble(textual_assembly);
+    auto annotator =
+        cantFail(ExegesisAnnotator::Create(*llvm_arch_support_, state));
+    return annotator->FindAccessedAddrs(llvm::ArrayRef(
+        reinterpret_cast<const uint8_t*>(code.data()), code.size()));
   }
 };
 
@@ -159,6 +177,25 @@ TEST_F(FindAccessedAddrsTest, AccessFromRegister) {
   )asm"),
               IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks,
                                  ElementsAre(0x10000, 0x20000))));
+}
+
+TEST_F(FindAccessedAddrsTest, ExegesisNoAccess) {
+  auto addrs_or_err = FindAccessedAddrsExegesis(R"asm(
+    mov r11, r12
+  )asm");
+  ASSERT_TRUE(static_cast<bool>(addrs_or_err));
+  AccessedAddrs Result = *addrs_or_err;
+  EXPECT_EQ(Result.accessed_blocks.size(), 0);
+}
+
+TEST_F(FindAccessedAddrsTest, ExegesisOneAccess) {
+  auto addrs_or_err = FindAccessedAddrsExegesis(R"asm(
+    mov [0x10000], rax
+  )asm");
+  ASSERT_TRUE(static_cast<bool>(addrs_or_err));
+  AccessedAddrs Result = *addrs_or_err;
+  EXPECT_EQ(Result.accessed_blocks.size(), 1);
+  EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
 }
 
 }  // namespace


### PR DESCRIPTION
This patch adds in an alternative to the existing find_accessed_addrs infrastructure that uses llvm-exegesis as a backend. We believe this will more closely match the execution environment of the benchmarking environment and should avoid some of the pitfalls of the existing memory annotation infrastructure (at the current expense of speed).