### PR TITLE
Set Bazel version in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -90,6 +90,8 @@ jobs:
   check-bazel:
     name: Run bazel build
     runs-on: ubuntu-latest
+    env:
+      USE_BAZEL_VERSION: 6.4.0
     steps:
     - uses: actions/checkout@v3
     - name: Cache Bazel


### PR DESCRIPTION
Currently the Bazel build is failing due to the CI trying to pull in bazel v7.0.0. This patch pins the bazel version to v6.4.0 which gets the CI green again, allowing further time to work on performing the necessary migration steps to get everything working properly with v7.0.0.