### PR TITLE
Make exegesis annotator work with mappings that aren't page aligned

### DIFF
--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -146,8 +146,9 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     handleAllErrors(std::move(std::get<0>(BenchmarkResultOrErr)),
                     [&](SnippetSegmentationFault &CrashInfo) {
                       MemoryMapping MemMap;
-                      uintptr_t MapAddress =
-                          (CrashInfo.getAddress() / 4096) * 4096;
+                      // Zero out the last twelve bits of the address to align
+                      // the address to a page boundary.
+                      uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
                       MemMap.Address = MapAddress;
                       MemMap.MemoryValueName = "memdef1";
                       BenchCode.Key.MemoryMappings.push_back(MemMap);

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -146,7 +146,8 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     handleAllErrors(std::move(std::get<0>(BenchmarkResultOrErr)),
                     [&](SnippetSegmentationFault &CrashInfo) {
                       MemoryMapping MemMap;
-                      uintptr_t MapAddress = (CrashInfo.getAddress() / 4096) * 4096;
+                      uintptr_t MapAddress =
+                          (CrashInfo.getAddress() / 4096) * 4096;
                       MemMap.Address = MapAddress;
                       MemMap.MemoryValueName = "memdef1";
                       BenchCode.Key.MemoryMappings.push_back(MemMap);

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -146,7 +146,8 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     handleAllErrors(std::move(std::get<0>(BenchmarkResultOrErr)),
                     [&](SnippetSegmentationFault &CrashInfo) {
                       MemoryMapping MemMap;
-                      MemMap.Address = CrashInfo.getAddress();
+                      uintptr_t MapAddress = (CrashInfo.getAddress() / 4096) * 4096;
+                      MemMap.Address = MapAddress;
                       MemMap.MemoryValueName = "memdef1";
                       BenchCode.Key.MemoryMappings.push_back(MemMap);
                     });

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -102,5 +102,16 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisOneAccess) {
   EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
 }
 
+TEST_F(FindAccessedAddrsExegesisTest, ExegesisNotPageAligned) {
+  auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
+    movq $0x10001, %rax
+    movq (%rax), %rax
+  )asm");
+  ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
+  AccessedAddrs Result = *AddrsOrErr;
+  EXPECT_EQ(Result.accessed_blocks.size(), 1);
+  EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
+}
+
 }  // namespace
 }  // namespace gematria


### PR DESCRIPTION
This patch makes the exegesis annotator work with mappings that are not page aligned. Currently if a segfault occurs at an address that isn't page aligned, Exegesis will try and map an address at that address and then the mmap call will silently fail as there is no error handling wired up for that and it will segfault again, thus creating a loop within the annotator.