### PR TITLE
Bump Bazelisk version in container to 1.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y clang python3 python3-pip git curl
-ARG bazelisk_version=1.17.0
+ARG bazelisk_version=1.19.0
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk_version}/bazelisk-linux-amd64 > /usr/bin/bazelisk && chmod +x /usr/bin/bazelisk && ln -s /usr/bin/bazelisk /usr/bin/bazel
 WORKDIR /gematria
 COPY . .


### PR DESCRIPTION
Nothing currently wrong with the old bazelisk version, but we're two minor versions out of date at this point and there's no real point in not updating.