### PR TITLE
Make exegesis conversion script use appropriate register class

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -71,14 +71,12 @@ int main(int argc, char* argv[]) {
 
   // Iterate through all general purpose registers and vector registers
   // and add them to the register definitions.
-  for (unsigned i = 0;
-       i < reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getNumRegs();
-       ++i) {
-    if (reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getRegister(i) ==
-        llvm::X86::RIP)
-      continue;
-    llvm::StringRef reg_name = reg_info.getName(
-        reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getRegister(i));
+  const auto& gr64_register_class =
+      reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID);
+  for (unsigned i = 0; i < gr64_register_class.getNumRegs(); ++i) {
+    if (gr64_register_class.getRegister(i) == llvm::X86::RIP) continue;
+    llvm::StringRef reg_name =
+        reg_info.getName(gr64_register_class.getRegister(i));
     register_defs_lines += llvm::Twine(kRegDefPrefix)
                                .concat(reg_name)
                                .concat(" ")
@@ -86,10 +84,11 @@ int main(int argc, char* argv[]) {
                                .concat("\n")
                                .str();
   }
-  for (unsigned i = 0;
-       i < reg_info.getRegClass(llvm::X86::VR128RegClassID).getNumRegs(); ++i) {
-    llvm::StringRef reg_name = reg_info.getName(
-        reg_info.getRegClass(llvm::X86::VR128RegClassID).getRegister(i));
+  const auto& vr128_register_class =
+      reg_info.getRegClass(llvm::X86::VR128RegClassID);
+  for (unsigned i = 0; i < vr128_register_class.getNumRegs(); ++i) {
+    llvm::StringRef reg_name =
+        reg_info.getName(vr128_register_class.getRegister(i));
     register_defs_lines += llvm::Twine(kRegDefPrefix)
                                .concat(reg_name)
                                .concat(" ")

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -71,14 +71,11 @@ int main(int argc, char* argv[]) {
 
   // Iterate through all general purpose registers and vector registers
   // and add them to the register definitions.
-  // TODO(9Temptest): Change GR64_NOREXRegClassID to GR64_NOREX2RegClassID when
-  // the LLVM version is bumped to avoid including the new APX GPRs (r16-r31)
-  // that have recently been added to LLVM.
   for (unsigned i = 0;
-       i < reg_info.getRegClass(llvm::X86::GR64_NOREXRegClassID).getNumRegs();
+       i < reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getNumRegs();
        ++i) {
     llvm::StringRef reg_name = reg_info.getName(
-        reg_info.getRegClass(llvm::X86::GR64_NOREXRegClassID).getRegister(i));
+        reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getRegister(i));
     register_defs_lines += llvm::Twine(kRegDefPrefix)
                                .concat(reg_name)
                                .concat(" ")

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -74,6 +74,9 @@ int main(int argc, char* argv[]) {
   for (unsigned i = 0;
        i < reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getNumRegs();
        ++i) {
+    if (reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getRegister(i) ==
+        llvm::X86::RIP)
+      continue;
     llvm::StringRef reg_name = reg_info.getName(
         reg_info.getRegClass(llvm::X86::GR64_NOREX2RegClassID).getRegister(i));
     register_defs_lines += llvm::Twine(kRegDefPrefix)


### PR DESCRIPTION
This patch fixes the register class that the BHive to Exegesis conversion script uses. Currently it is only pulling in registers that don't have a REX encoding, which doesn't even include R9-R15. This patch fixes that behavior by using the more generic LLVM 64-bit GPR Register class, but specifically looking at registers that don't require a REX2 encoding, as there is no hardware in the wild yet that supports APX.