### PR TITLE
Change constants in BHive conversion script

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -29,6 +29,10 @@
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/utils/string.h"
 
+// Use the constants from the BHive paper for setting initial register and
+// memory values. These constants are set to a high enough value to avoid
+// underflow and accesses within the first page, but low enough to avoid
+// exceeding the virtual address space ceiling in most cases.
 constexpr uint64_t kInitialRegVal = 0x12345600;
 constexpr uint64_t kInitialMemVal = 0x12345600;
 constexpr unsigned kInitialMemValBitWidth = 64;

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -29,8 +29,9 @@
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/utils/string.h"
 
-constexpr uint64_t kInitialRegVal = 0x10000;
-constexpr uint64_t kInitialMemVal = 0x7FFFFFFF;
+constexpr uint64_t kInitialRegVal = 0x12345600;
+constexpr uint64_t kInitialMemVal = 0x12345600;
+constexpr unsigned kInitialMemValBitWidth = 64;
 constexpr std::string_view kRegDefPrefix = "# LLVM-EXEGESIS-DEFREG ";
 constexpr std::string_view kMemDefPrefix = "# LLVM-EXEGESIS-MEM-DEF ";
 constexpr std::string_view kMemMapPrefix = "# LLVM-EXEGESIS-MEM-MAP ";
@@ -64,6 +65,14 @@ int main(int argc, char* argv[]) {
       gematria::ConvertHexToString(kInitialRegVal);
   std::string initial_mem_val_str =
       gematria::ConvertHexToString(kInitialMemVal);
+  // Prefix the string with zeroes as llvm-exegesis assumes the bit width
+  // of the memory value based on the number of characters in the string.
+  if (kInitialMemValBitWidth > initial_mem_val_str.size() * 4)
+    initial_mem_val_str =
+        std::string(
+            (kInitialMemValBitWidth - initial_mem_val_str.size() * 4) / 4,
+            '0') +
+        initial_mem_val_str;
   std::string register_defs_lines;
   const std::unique_ptr<gematria::LlvmArchitectureSupport> llvm_support =
       gematria::LlvmArchitectureSupport::X86_64();


### PR DESCRIPTION
This patch adjusts the constants in the BHive conversion script from the default values added in with the script to the values used within the original BHive paper. These constants were experimentally determined within the BHive paper to be high enough to not underflow/access addresses in the first page yet low enough to not access any addresses above the virtual address space ceiling. Anecdotally, these constants have also seemed to work better than the original ones. In addition, this patch prefixes the memory value with zeroes so that llvm-exegesis is able to assume the correct bit width.