### PR TITLE
Address PR feedback in convert_bhive_to_llvm_exegesis_input

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -36,10 +36,6 @@ constexpr std::string_view kMemDefPrefix = "# LLVM-EXEGESIS-MEM-DEF ";
 constexpr std::string_view kMemMapPrefix = "# LLVM-EXEGESIS-MEM-MAP ";
 constexpr std::string_view kMemNamePrefix = "MEM";
 
-namespace {
-unsigned int file_counter = 0;
-}
-
 ABSL_FLAG(std::string, bhive_csv, "", "Filename of the input BHive CSV file");
 ABSL_FLAG(
     std::string, output_dir, "",
@@ -102,6 +98,7 @@ int main(int argc, char* argv[]) {
   gematria::BHiveImporter bhive_importer(&canonicalizer);
 
   std::ifstream bhive_csv_file(bhive_filename);
+  unsigned int file_counter = 0;
   for (std::string line; std::getline(bhive_csv_file, line);) {
     auto comma_index = line.find(',');
     if (comma_index == std::string::npos) {


### PR DESCRIPTION
This patch moves `file_counter` out of the global scope to where it is relevant in `main`, as requested in the original review.