### PR TITLE
Add test target for llvm-cm

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ ninja llvm-granite llvm-cm
 Where `LLVM_PROJECT_SRC` is the absolute path to your local llvm repo, and
 `GEMATRIA_SRC` the path to this (the gematria) repo.
 
+To run the `llvm-cm` tests, you can run the following target:
+
+```shell
+ninja check-llvm-tools-llvm-cm
+```
+
 ### Platform Support
 
 We develop and test our code on Linux and x86-64, and we test it on Mac OS X and

--- a/llvm_cm/CMakeLists.txt
+++ b/llvm_cm/CMakeLists.txt
@@ -1,1 +1,11 @@
 add_subdirectory(tools)
+
+configure_lit_site_cfg(
+  "${CMAKE_CURRENT_SOURCE_DIR}/test/lit.site.cfg.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg"
+)
+
+add_lit_testsuite(check-llvm-tools-llvm-cm "Running llvm-cm tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "llvm-cm" "yaml2obj" "not" "FileCheck" "count" "split-file" "llvm-mc"
+)

--- a/llvm_cm/test/X86/bb-frequency.s
+++ b/llvm_cm/test/X86/bb-frequency.s
@@ -1,5 +1,4 @@
 ## LLVM-CM frequency weighting test.
-# REQUIRES: x86
 # RUN: split-file %s %t
 # RUN: llvm-mc -o %t.o --filetype=obj -triple=x86_64-unknown-linux-gnu %t/bb-frequency-test.s
 # RUN: llvm-cm %t.o --csv=%t/bb-frequency.csv -granite_model=%S/Inputs/gb-token-mit-2022_12_02.tflite -evaluator=granite| FileCheck %t/bb-frequency-test.s

--- a/llvm_cm/test/X86/bb-frequency.s
+++ b/llvm_cm/test/X86/bb-frequency.s
@@ -1,5 +1,4 @@
 ## LLVM-CM frequency weighting test.
-# REQUIRES: x86-registered-target
 # RUN: split-file %s %t
 # RUN: llvm-mc -o %t.o --filetype=obj -triple=x86_64-unknown-linux-gnu %t/bb-frequency-test.s
 # RUN: llvm-cm %t.o --csv=%t/bb-frequency.csv -granite_model=%S/Inputs/gb-token-mit-2022_12_02.tflite -evaluator=granite| FileCheck %t/bb-frequency-test.s

--- a/llvm_cm/test/X86/bb-frequency.s
+++ b/llvm_cm/test/X86/bb-frequency.s
@@ -1,4 +1,5 @@
 ## LLVM-CM frequency weighting test.
+# REQUIRES: target-x86_64, native
 # RUN: split-file %s %t
 # RUN: llvm-mc -o %t.o --filetype=obj -triple=x86_64-unknown-linux-gnu %t/bb-frequency-test.s
 # RUN: llvm-cm %t.o --csv=%t/bb-frequency.csv -granite_model=%S/Inputs/gb-token-mit-2022_12_02.tflite -evaluator=granite| FileCheck %t/bb-frequency-test.s

--- a/llvm_cm/test/X86/bb-frequency.s
+++ b/llvm_cm/test/X86/bb-frequency.s
@@ -1,4 +1,5 @@
 ## LLVM-CM frequency weighting test.
+# REQUIRES: x86-registered-target
 # RUN: split-file %s %t
 # RUN: llvm-mc -o %t.o --filetype=obj -triple=x86_64-unknown-linux-gnu %t/bb-frequency-test.s
 # RUN: llvm-cm %t.o --csv=%t/bb-frequency.csv -granite_model=%S/Inputs/gb-token-mit-2022_12_02.tflite -evaluator=granite| FileCheck %t/bb-frequency-test.s

--- a/llvm_cm/test/X86/lit.local.cfg
+++ b/llvm_cm/test/X86/lit.local.cfg
@@ -1,2 +1,0 @@
-if not "X86" in config.root.targets:
-    config.unsupported = True

--- a/llvm_cm/test/lit.cfg
+++ b/llvm_cm/test/lit.cfg
@@ -1,0 +1,19 @@
+import os
+
+import lit.formats
+
+from lit.llvm import llvm_config
+
+config.name = "llvm-cm"
+config.test_format = lit.formats.ShTest(execute_external=False)
+
+config.suffixes = [".s", ".test"]
+
+config.test_source_root = os.path.dirname(__file__)
+config.test_exec_root = config.obj_root
+
+llvm_config.use_default_substitutions()
+config.substitutions.append(("yaml2obj", llvm_config.use_llvm_tool("yaml2obj")))
+config.substitutions.append(("llvm-cm", llvm_config.use_llvm_tool("llvm-cm")))
+config.substitutions.append(("split-file", llvm_config.use_llvm_tool("split-file")))
+config.substitutions.append(("llvm-mc", llvm_config.use_llvm_tool("llvm-mc")))

--- a/llvm_cm/test/lit.cfg
+++ b/llvm_cm/test/lit.cfg
@@ -17,6 +17,3 @@ config.substitutions.append(("yaml2obj", llvm_config.use_llvm_tool("yaml2obj")))
 config.substitutions.append(("llvm-cm", llvm_config.use_llvm_tool("llvm-cm")))
 config.substitutions.append(("split-file", llvm_config.use_llvm_tool("split-file")))
 config.substitutions.append(("llvm-mc", llvm_config.use_llvm_tool("llvm-mc")))
-
-for arch in config.targets_to_build.split():
-    config.available_features.add(arch.lower() + "-registered-target")

--- a/llvm_cm/test/lit.cfg
+++ b/llvm_cm/test/lit.cfg
@@ -17,3 +17,6 @@ config.substitutions.append(("yaml2obj", llvm_config.use_llvm_tool("yaml2obj")))
 config.substitutions.append(("llvm-cm", llvm_config.use_llvm_tool("llvm-cm")))
 config.substitutions.append(("split-file", llvm_config.use_llvm_tool("split-file")))
 config.substitutions.append(("llvm-mc", llvm_config.use_llvm_tool("llvm-mc")))
+
+for arch in config.targets_to_build.split():
+    config.available_features.add(arch.lower() + "-registered-target")

--- a/llvm_cm/test/lit.site.cfg.in
+++ b/llvm_cm/test/lit.site.cfg.in
@@ -3,6 +3,7 @@
 config.src_root = "@LLVM_SOURCE_DIR@"
 config.obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.targets_to_build = "@TARGETS_TO_BUILD@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/llvm_cm/test/lit.site.cfg.in
+++ b/llvm_cm/test/lit.site.cfg.in
@@ -3,7 +3,6 @@
 config.src_root = "@LLVM_SOURCE_DIR@"
 config.obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
-config.targets_to_build = "@TARGETS_TO_BUILD@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/llvm_cm/test/lit.site.cfg.in
+++ b/llvm_cm/test/lit.site.cfg.in
@@ -1,5 +1,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.src_root = "@LLVM_SOURCE_DIR@"
 config.obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")

--- a/llvm_cm/test/lit.site.cfg.in
+++ b/llvm_cm/test/lit.site.cfg.in
@@ -1,0 +1,10 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+config.src_root = "@LLVM_SOURCE_DIR@"
+config.obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+lit_config.load_config(config, "@LLVM_EXTERNAL_GEMATRIA_SOURCE_DIR@/llvm_cm/test/lit.cfg")


### PR DESCRIPTION
This patch sets up a ninja target for testing llvm-cm, akin to the tool specific test targets in the monorepo. This allows for actually running the tests. Documentation has been added to the README.