### PR TITLE
Fix llvm-cm after switch to BBRanges

### DIFF
--- a/llvm_cm/tools/llvm-cm/llvm-cm.cpp
+++ b/llvm_cm/tools/llvm-cm/llvm-cm.cpp
@@ -367,8 +367,9 @@ static void collectBBtoAddressLabels(
   const uint64_t EndAddress = SectionAddr + End;
   auto Iter = AddrToBBAddrMap.find(StartAddress);
   if (Iter == AddrToBBAddrMap.end()) return;
-  for (const llvm::object::BBAddrMap::BBEntry &BB : Iter->second.BBEntries) {
-    const uint64_t BBAddress = BB.Offset + Iter->second.Addr;
+  for (const llvm::object::BBAddrMap::BBEntry &BB :
+       Iter->second.getBBEntries()) {
+    const uint64_t BBAddress = BB.Offset + Iter->second.getFunctionAddress();
     if (BBAddress >= EndAddress) continue;
     Labels[BBAddress].push_back(BB.ID);
   }
@@ -542,7 +543,7 @@ int main(int argc, char *argv[]) {
       auto BBAddrMappingOrErr = Elf->readBBAddrMap();
       exitIf(!BBAddrMappingOrErr, "failed to read basic block address mapping");
       for (auto &BBAddr : *BBAddrMappingOrErr) {
-        BBAddrMap.try_emplace(BBAddr.Addr, std::move(BBAddr));
+        BBAddrMap.try_emplace(BBAddr.getFunctionAddress(), std::move(BBAddr));
       }
     }
   };


### PR DESCRIPTION
A couple additional cases were recently added into the BB Address Map section in https://github.com/llvm/llvm-project/pull/74128. This broke llvm-cm as a couple method names changed. This patch provides the quick fix to get everything working.

Eventually llvm-cm will need some work to support multiple BBRanges within a single function.