### PR TITLE
Add llvm-cm check target to CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: build
         run: |
           cd /tmp/cmake-build
-          ninja llvm-granite llvm-cm
+          ninja llvm-granite check-llvm-tools-llvm-cm
   check-bazel:
     name: Run bazel build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that the check target is wired up through CMake, we should test this through CI to ensure that there aren't any regressions.