### PR TITLE
Make --blocks-per-json-file unsigned

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -138,7 +138,8 @@ int main(int argc, char* argv[]) {
   const std::string json_output_dir = absl::GetFlag(FLAGS_json_output_dir);
   const std::string asm_output_dir = absl::GetFlag(FLAGS_asm_output_dir);
 
-  const int blocks_per_json_file = absl::GetFlag(FLAGS_blocks_per_json_file);
+  const unsigned blocks_per_json_file =
+      absl::GetFlag(FLAGS_blocks_per_json_file);
   if (blocks_per_json_file <= 0) {
     std::cerr << "Error: --blocks_per_json_file must be greater than 1.\n";
     return 1;


### PR DESCRIPTION
Before this patch, --blocks-per-json-file was setup as unsigned in the flag definitions, but the value was assigned to a normal int later on. This resulted in the check that the value is <= triggering with the default value of the maximum unsigned 32 bit integer. This patch fixes that by assigning the value of the flag to an unsigned value rather than a normal int.