### PR TITLE
Add progress reporting flag to annotator script

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -88,9 +88,8 @@ ABSL_FLAG(
     "The number of annotated basic blocks to include in a single JSON file");
 ABSL_FLAG(unsigned, max_bb_count, std::numeric_limits<unsigned>::max(),
           "The maximum number of basic blocks to process");
-ABSL_FLAG(
-    bool, report_progress, false,
-    "Whether or not to report progress after annotating each basic block.");
+ABSL_FLAG(unsigned, report_progress_every, std::numeric_limits<unsigned>::max(),
+          "The number of blocks after which to report progress.");
 
 absl::StatusOr<gematria::AccessedAddrs> GetAccessedAddrs(
     absl::Span<const uint8_t> basic_block,
@@ -220,7 +219,8 @@ int main(int argc, char* argv[]) {
   std::ifstream bhive_csv_file(bhive_filename);
   llvm::json::Array processed_snippets;
   const unsigned max_bb_count = absl::GetFlag(FLAGS_max_bb_count);
-  const bool report_progress = absl::GetFlag(FLAGS_report_progress);
+  const unsigned report_progress_every =
+      absl::GetFlag(FLAGS_report_progress_every);
   unsigned int file_counter = 0;
   for (std::string line; std::getline(bhive_csv_file, line);) {
     if (file_counter >= max_bb_count) break;
@@ -336,8 +336,8 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    if (report_progress)
-      std::cout << "Finished annotating block #" << file_counter << ".\n";
+    if (file_counter % report_progress_every == 0)
+      std::cerr << "Finished annotating block #" << file_counter << ".\n";
 
     file_counter++;
   }

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -88,6 +88,9 @@ ABSL_FLAG(
     "The number of annotated basic blocks to include in a single JSON file");
 ABSL_FLAG(unsigned, max_bb_count, std::numeric_limits<unsigned>::max(),
           "The maximum number of basic blocks to process");
+ABSL_FLAG(
+    bool, report_progress, false,
+    "Whether or not to report progress after annotating each basic block.");
 
 absl::StatusOr<gematria::AccessedAddrs> GetAccessedAddrs(
     absl::Span<const uint8_t> basic_block,
@@ -217,6 +220,7 @@ int main(int argc, char* argv[]) {
   std::ifstream bhive_csv_file(bhive_filename);
   llvm::json::Array processed_snippets;
   const unsigned max_bb_count = absl::GetFlag(FLAGS_max_bb_count);
+  const bool report_progress = absl::GetFlag(FLAGS_report_progress);
   unsigned int file_counter = 0;
   for (std::string line; std::getline(bhive_csv_file, line);) {
     if (file_counter >= max_bb_count) break;
@@ -331,6 +335,9 @@ int main(int argc, char* argv[]) {
         processed_snippets.clear();
       }
     }
+
+    if (report_progress)
+      std::cout << "Finished annotating block #" << file_counter << ".\n";
 
     file_counter++;
   }


### PR DESCRIPTION
This patch adds a progress reporting flag to the annotator script. This can be quite useful when using a slower implementation of FindAccessedAddrs like FindAccessedAddrsExegesis to get a gauge on what sort of progress is being made and to show that the application isn't stuck somewhere when processing a large number of blocks.