### PR TITLE
Fix off by one error in annotator JSON output

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -324,7 +324,7 @@ int main(int argc, char* argv[]) {
       processed_snippets.push_back(
           llvm::json::Value(std::move(current_snippet)));
 
-      if (file_counter % blocks_per_json_file == 0) {
+      if ((file_counter + 1) % blocks_per_json_file == 0) {
         size_t json_file_number = file_counter / blocks_per_json_file;
         bool write_successfully = WriteJsonFile(
             std::move(processed_snippets), json_file_number, json_output_dir);


### PR DESCRIPTION
This patch fixes an off-by-one error in the annotator JSON output. Essentially, the very first block would automatically trigger a write to the file since the file count was zero, and zero modulo anything is still zero, which was the condition for writing to a file. This becomes a problem if there are fewer blocks than blocks_per_json_file as after processing all the blocks, the final chunk will be written, but it will overwrite the first chunk in this case, leaving blocks out. This patch fixes that behavior by simpling computing the module with file_counter +1, which has the same effect but avoids this behavior.