### PR TITLE
Add function to create proto from disassembled instructions

### DIFF
--- a/gematria/datasets/bhive_importer.cc
+++ b/gematria/datasets/bhive_importer.cc
@@ -63,9 +63,9 @@ BHiveImporter::BHiveImporter(const Canonicalizer* canonicalizer)
           *target_machine_.getMCAsmInfo(), *target_machine_.getMCInstrInfo(),
           *target_machine_.getMCRegisterInfo())) {}
 
-
 BasicBlockProto BHiveImporter::BasicBlockProtoFromInstructions(
-  llvm::ArrayRef<DisassembledInstruction> disassembled_instructions, uint64_t base_address /*= 0*/) {
+    llvm::ArrayRef<DisassembledInstruction> disassembled_instructions,
+    uint64_t base_address /*= 0*/) {
   BasicBlockProto basic_block_proto;
   for (const DisassembledInstruction& instruction : disassembled_instructions) {
     MachineInstructionProto& machine_instruction =

--- a/gematria/datasets/bhive_importer.h
+++ b/gematria/datasets/bhive_importer.h
@@ -43,18 +43,21 @@ class BHiveImporter {
   // Does not take ownership of the canonicalizer.
   explicit BHiveImporter(const Canonicalizer* canonicalizer);
 
+  // Creates a basic block from the given instructions. Uses `base_address` as
+  // the address of the first instruction; the addresses of following
+  // instructions are derived from `base_address` and the sizes of the
+  // instructions that preceded it.
   BasicBlockProto BasicBlockProtoFromInstructions(
-     llvm::ArrayRef<DisassembledInstruction> disassembled_instructions, uint64_t base_address = 0); 
+      llvm::ArrayRef<DisassembledInstruction> disassembled_instructions,
+      uint64_t base_address = 0);
 
-  // Creates a basic block from the given block of machine code. `machine_code`
-  // must contain machine code of the instructions to include in the basic
-  // block. Expects that the `machine_code.begin()` is the first byte of the
-  // first instruction, and `machine_code.rbegin()` is the last byte of the last
-  // instruction. Uses `base_address` as the address of the first instruction;
-  // the addresses of following instructions are derived from `base_address` and
-  // the sizes of the instructions that preceded it.
-  // Returns an error when parts of `machine_code` do not disassemble using the
-  // provided canonicalizer.
+  // A version of BasicBlockProtoFromInstructions. Creates a basic block from
+  // the given block of machine code. `machine_code` must contain machine code
+  // of the instructions to include in the basic block. Expects that the
+  // `machine_code.begin()` is the first byte of the first instruction, and
+  // `machine_code.rbegin()` is the last byte of the last instruction. Returns
+  // an error when parts of `machine_code` do not disassemble using the provided
+  // canonicalizer.
   absl::StatusOr<BasicBlockProto> BasicBlockProtoFromMachineCode(
       llvm::ArrayRef<uint8_t> machine_code, uint64_t base_address = 0);
 

--- a/gematria/datasets/bhive_importer.h
+++ b/gematria/datasets/bhive_importer.h
@@ -24,6 +24,7 @@
 
 #include "absl/status/statusor.h"
 #include "gematria/llvm/canonicalizer.h"
+#include "gematria/llvm/disassembler.h"
 #include "gematria/proto/basic_block.pb.h"
 #include "gematria/proto/throughput.pb.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -41,6 +42,9 @@ class BHiveImporter {
   // must be for the architecture/microarchitecture of the data set.
   // Does not take ownership of the canonicalizer.
   explicit BHiveImporter(const Canonicalizer* canonicalizer);
+
+  BasicBlockProto BasicBlockProtoFromInstructions(
+     llvm::ArrayRef<DisassembledInstruction> disassembled_instructions, uint64_t base_address = 0); 
 
   // Creates a basic block from the given block of machine code. `machine_code`
   // must contain machine code of the instructions to include in the basic


### PR DESCRIPTION
This patch adds a new function that refactors out some functionality from the existing proto generation functions to create a proto directly from disassembled instructions. This allows user to do their own disassembly (like for easy access to the llvm MCInsts) and efficiently create a proto afterwards.