### PR TITLE
Enable Bazel tests in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,6 +102,15 @@ jobs:
         key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
         restore-keys: |
           ${{ runner.os }}-bazel-
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install python deps
+      run: pip3 install -r requirements.in
     - name: Run build
       run: bazel build ...
+    - name: Run tests
+      run: bazel test --test_tag_filters="-perf_counters" ...
 

--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -138,6 +138,7 @@ cc_test(
     # the tests are currently only supported on X86_64.
     tags = [
         "not_build:arm",
+        "perf_counters",
     ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",


### PR DESCRIPTION
This patch enables running the Bazel tests in CI which allows us to automatically catch regressions and more easily ensure that PRs aren't breaking anything/the additional (tested) functionality is working properly. This patch doesn't enable anything using perf_counters to be tested in CI as Github Actions VMs don't have access to performance counters. This effect is achieved by creating a bazel test tag and excluding it on the bazel test invocation.