### PR TITLE
Add additional lit tests for Exegesis conversion script

### DIFF
--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -83,6 +83,7 @@ gematria_py_test(
         "tests/lit.site.cfg.py",
         ":convert_bhive_to_llvm_exegesis_input",
         "@llvm-project//llvm:FileCheck",
+        "@llvm-project//llvm:not",
         "@llvm-project//llvm:split-file",
     ] + glob(["tests/*.test"]),
 )

--- a/gematria/datasets/tests/blocks_per_json_file.test
+++ b/gematria/datasets/tests/blocks_per_json_file.test
@@ -1,0 +1,52 @@
+; Test that splitting a dataset among multiple JSON files works as expected.
+
+; Test currently fails as underlying functionality needs to be fixed, see #61.
+; XFAIL: *
+
+; RUN: split-file %s %t
+; RUN: mkdir %t.jsondir
+; RUN: %convert_bhive_to_llvm_exegesis_input --json_output_dir=%t.jsondir --bhive_csv=%t/test.csv
+; RUN: cat %t.jsondir/0.json | FileCheck --check-prefix FILE1 %s
+; RUN: cat %t.jsondir/1.json | FileCheck --check-prefix FILE2 %s
+
+; FILE1-CHECK: [
+; FILE1-CHECK:   {
+; FILE1-CHECK:     "Hex": "85c044897c2460",
+; FILE1-CHECK:     "MemoryDefinitions": [
+; FILE1-CHECK:       {
+; FILE1-CHECK:         "Name": "MEM",
+; FILE1-CHECK:         "Size": 4096,
+; FILE1-CHECK:         "Value": 305419776
+; FILE1-CHECK:       }
+; FILE1-CHECK:     ],
+; FILE1-CHECK:     "MemoryMappings": [
+; FILE1-CHECK:       {
+; FILE1-CHECK:         "Address": 65536,
+; FILE1-CHECK:         "Value": "MEM"
+; FILE1-CHECK:       }
+; FILE1-CHECK:     ]
+; FILE1-CHECK:   }
+; FILE1-CHECK: ]
+
+; FILE2-CHECK: [
+; FILE2-CHECK:   {
+; FILE2-CHECK:     "Hex": "3b31",
+; FILE2-CHECK:     "MemoryDefinitions": [
+; FILE2-CHECK:       {
+; FILE2-CHECK:         "Name": "MEM",
+; FILE2-CHECK:         "Size": 4096,
+; FILE2-CHECK:         "Value": 305419776
+; FILE2-CHECK:       }
+; FILE2-CHECK:     ],
+; FILE2-CHECK:     "MemoryMappings": [
+; FILE2-CHECK:       {
+; FILE2-CHECK:         "Address": 65536,
+; FILE2-CHECK:         "Value": "MEM"
+; FILE2-CHECK:       }
+; FILE2-CHECK:     ]
+; FILE2-CHECK:   }
+; FILE2-CHECK: ]
+
+;--- test.csv
+3b31,45.000000
+85c044897c2460,98.000000

--- a/gematria/datasets/tests/flag_errors.test
+++ b/gematria/datasets/tests/flag_errors.test
@@ -1,0 +1,22 @@
+; Test various flag combinations that should result in an error.
+
+; Test that not passing in any flags results in an error.
+; RUN: %not %convert_bhive_to_llvm_exegesis_input 2>&1 | FileCheck %s --check-prefix=NO-ARGS
+
+; NO-ARGS: Error: --bhive_csv is required
+
+; Test that setting a number of blocks per JSON file less than 1 results in
+; an error.
+; RUN: split-file %s %t
+; RUN: mkdir %t.asmdir
+; RUN: %not %convert_bhive_to_llvm_exegesis_input --bhive_csv=%t/test.csv --asm_output_dir=%t.asmdir --blocks_per_json_file=0 2>&1 | FileCheck %s --check-prefix=BAD-BLOCK-COUNT
+
+; BAD-BLOCK-COUNT: Error: --blocks_per_json_file must be greater than 1.
+
+; Test that specifying an unknown annotator type results in an error.
+; RUN: %not %convert_bhive_to_llvm_exegesis_input --bhive_csv=%t/test.csv --asm_output_dir=%t.asmdir --annotator_implementation=doesntexist 2>&1 | FileCheck %s --check-prefix=BAD-ANNOTATOR-TYPE
+
+; BAD-ANNOTATOR-TYPE: ERROR: Illegal value 'doesntexist' specified for flag 'annotator_implementation'; unknown annotator type
+
+;--- test.csv
+3b31,45.000000

--- a/gematria/datasets/tests/lit.cfg.py
+++ b/gematria/datasets/tests/lit.cfg.py
@@ -14,6 +14,9 @@ config.substitutions.append(
 config.substitutions.append(
     ('split-file', os.path.join(config.llvm_tools_root, 'split-file'))
 )
+config.substitutions.append(
+    ('%not', os.path.join(config.llvm_tools_root, 'not'))
+)
 
 config.substitutions.append((
     '%convert_bhive_to_llvm_exegesis_input',

--- a/gematria/datasets/tests/max_bb_count.test
+++ b/gematria/datasets/tests/max_bb_count.test
@@ -1,0 +1,13 @@
+; Test that we only annotate up to --max_bb_count BBs.
+
+; RUN: split-file %s %t
+; RUN: mkdir %t.asmdir
+; RUN: %convert_bhive_to_llvm_exegesis_input --asm_output_dir=%t.asmdir --bhive_csv=%t/test.csv --max_bb_count=1
+; RUN: ls %t.asmdir | FileCheck %s
+
+; CHECK: 0.test
+; CHECK-NOT: 1.test
+
+;--- test.csv
+3b31,45.000000
+85c044897c2460,98.000000


### PR DESCRIPTION
This patch adds some additional lit regression tests for the Exegesis conversion script to test functionality that was previously implemented/improved now that we actually have testing facilities. This should cover all the recently landed PRs. More regression tests will come with time as bugs get fixed.