### PR TITLE
Improve --report_progress_every flag

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -337,7 +337,7 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    if (file_counter % report_progress_every == 0)
+    if (file_counter != 0 && file_counter % report_progress_every == 0)
       std::cerr << "Finished annotating block #" << file_counter << ".\n";
 
     file_counter++;

--- a/gematria/datasets/tests/report_progress.test
+++ b/gematria/datasets/tests/report_progress.test
@@ -1,0 +1,22 @@
+; Test that the --report_progress_every reports progress at the expected
+; intervals.
+
+; RUN: split-file %s %t
+; RUN: mkdir %t.asmdir
+; RUN: %convert_bhive_to_llvm_exegesis_input --asm_output_dir=%t.asmdir --bhive_csv=%t/test.csv --report_progress_every=2 2>&1 | FileCheck %s
+
+; CHECK: Finished annotating block #2.
+; CHECK: Finished annotating block #4.
+
+; Test that --report_progress_every doesn't output anything with the default
+; value.
+; RUN: %convert_bhive_to_llvm_exegesis_input --asm_output_dir=%t.asmdir --bhive_csv=%t/test.csv 2>&1 | FileCheck %s --check-prefix=DEFAULT-VALUE
+
+; DEFAULT-VALUE-NOT: Finished annotating block
+
+;--- test.csv
+4183ff0119c083e00885c98945c4b8010000000f4fc139c2,298.000000
+4889de4889c24c89ff,93.000000
+48895d1844886520488945004889e84883c4085b5d415c415d,335.000000
+418b4424084d8b3424498d2cc64939ee,98.000000
+85c044897c2460,98.000000


### PR DESCRIPTION
Currently, the --report_progress_every flag, even with the default value, will always report progress on the first block. This is not the intended behavior, as no output should be given with the default value. This patch fixes that behavior and also adds a test to ensure that the flag functions as intended in the default value case and in the value-provided case.

Not really super critical to functionality, but a little bit annoying to have this.