### PR TITLE
Add support for filtering call and return instructions

### DIFF
--- a/gematria/datasets/process_and_filter_bbs.cc
+++ b/gematria/datasets/process_and_filter_bbs.cc
@@ -14,6 +14,7 @@
 
 #include <fstream>
 
+#include "X86InstrInfo.h"
 #include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/utils/string.h"
@@ -75,6 +76,9 @@ int main(int Argc, char **Argv) {
 
     for (const gematria::DisassembledInstruction &Instruction :
          DisassembledInstructions) {
+      MCInstrDesc InstDesc =
+          llvm_support->mc_instr_info().get(Instruction.mc_inst.getOpcode());
+      if (InstDesc.isReturn() || InstDesc.isCall()) continue;
       OutputFileStream << toHex(Instruction.machine_code);
     }
     OutputFileStream << "\n";


### PR DESCRIPTION
This patch adds support for filtering return and call instructions out of basic blocks, which make them impossible to benchmark due to a lack of surrounding context.