### PR TITLE
Add basic block utils library with function to calculate register usage

### DIFF
--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -184,3 +184,23 @@ cc_library(
     ],
     deps = ["@com_google_absl//absl/types:span"],
 )
+
+cc_library(
+    name = "basic_block_utils",
+    srcs = ["basic_block_utils.cc"],
+    hdrs = ["basic_block_utils.h"],
+    deps = ["//gematria/llvm:disassembler"]
+)
+
+cc_test(
+    name = "basic_block_utils_test",
+    srcs = ["basic_block_utils_test.cc"],
+    deps = [
+      ":basic_block_utils",
+      "//gematria/llvm:llvm_architecture_support",
+      "//gematria/llvm:asm_parser",
+      "//gematria/llvm:disassembler",
+      "//gematria/testing:matchers",
+      "@com_google_googletest//:gtest_main",
+    ]
+)

--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -196,11 +196,11 @@ cc_test(
     name = "basic_block_utils_test",
     srcs = ["basic_block_utils_test.cc"],
     deps = [
-      ":basic_block_utils",
-      "//gematria/llvm:llvm_architecture_support",
-      "//gematria/llvm:asm_parser",
-      "//gematria/llvm:disassembler",
-      "//gematria/testing:matchers",
-      "@com_google_googletest//:gtest_main",
+        ":basic_block_utils",
+        "//gematria/llvm:llvm_architecture_support",
+        "//gematria/llvm:asm_parser",
+        "//gematria/llvm:disassembler",
+        "//gematria/testing:matchers",
+        "@com_google_googletest//:gtest_main",
     ]
 )

--- a/gematria/datasets/basic_block_utils.cc
+++ b/gematria/datasets/basic_block_utils.cc
@@ -1,0 +1,54 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <map>
+
+#include "gematria/datasets/basic_block_utils.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCInstrInfo.h"
+
+using namespace llvm;
+
+namespace gematria {
+
+std::vector<unsigned> BasicBlockUtils::getUsedRegisters(const std::vector<DisassembledInstruction> &Instructions, const MCRegisterInfo &RegisterInfo, const MCInstrInfo &InstructionInfo) {
+  std::map<unsigned, bool> UsedRegisters;
+  for (const gematria::DisassembledInstruction& Instruction : Instructions) {
+    for (unsigned OperandIndex = 0;
+         OperandIndex < Instruction.mc_inst.getNumOperands();
+         ++OperandIndex) {
+      if (Instruction.mc_inst.getOperand(OperandIndex).isReg()) {
+        unsigned RegisterNumber =
+            Instruction.mc_inst.getOperand(OperandIndex).getReg();
+        if (RegisterNumber == 0) continue;
+        unsigned SuperRegisterNumber = 0;
+        for (MCPhysReg CurrentSuperRegister :
+             RegisterInfo.superregs_inclusive(RegisterNumber)) {
+          SuperRegisterNumber = CurrentSuperRegister;
+        }
+        UsedRegisters[SuperRegisterNumber] = true;
+      }
+    }
+  }
+
+  std::vector<unsigned> UsedRegistersList;
+  UsedRegistersList.reserve(UsedRegisters.size());
+
+  for (const auto [RegisterIndex, RegisterUsed] : UsedRegisters)
+    UsedRegistersList.push_back(RegisterIndex);
+
+  return UsedRegistersList;
+}
+
+} // namespace gematria

--- a/gematria/datasets/basic_block_utils.cc
+++ b/gematria/datasets/basic_block_utils.cc
@@ -12,22 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gematria/datasets/basic_block_utils.h"
+
 #include <map>
 
-#include "gematria/datasets/basic_block_utils.h"
-#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
 
 using namespace llvm;
 
 namespace gematria {
 
-std::vector<unsigned> BasicBlockUtils::getUsedRegisters(const std::vector<DisassembledInstruction> &Instructions, const MCRegisterInfo &RegisterInfo, const MCInstrInfo &InstructionInfo) {
+std::vector<unsigned> BasicBlockUtils::getUsedRegisters(
+    const std::vector<DisassembledInstruction> &Instructions,
+    const MCRegisterInfo &RegisterInfo, const MCInstrInfo &InstructionInfo) {
   std::map<unsigned, bool> UsedRegisters;
-  for (const gematria::DisassembledInstruction& Instruction : Instructions) {
+  for (const gematria::DisassembledInstruction &Instruction : Instructions) {
     for (unsigned OperandIndex = 0;
-         OperandIndex < Instruction.mc_inst.getNumOperands();
-         ++OperandIndex) {
+         OperandIndex < Instruction.mc_inst.getNumOperands(); ++OperandIndex) {
       if (Instruction.mc_inst.getOperand(OperandIndex).isReg()) {
         unsigned RegisterNumber =
             Instruction.mc_inst.getOperand(OperandIndex).getReg();
@@ -51,4 +53,4 @@ std::vector<unsigned> BasicBlockUtils::getUsedRegisters(const std::vector<Disass
   return UsedRegistersList;
 }
 
-} // namespace gematria
+}  // namespace gematria

--- a/gematria/datasets/basic_block_utils.h
+++ b/gematria/datasets/basic_block_utils.h
@@ -1,0 +1,39 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains utilities for analying and manipulating basic blocks.
+
+#ifndef THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_
+#define THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_
+
+#include <vector>
+
+#include "gematria/llvm/disassembler.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCInstrInfo.h"
+
+namespace gematria {
+
+using namespace llvm;
+
+// Basic Block Utilities.
+class BasicBlockUtils {
+public:
+  // Gets the registers used by a basic block (in the form of a sequence of
+  // instructions).
+  static std::vector<unsigned> getUsedRegisters(const std::vector<DisassembledInstruction> &Instructions, const MCRegisterInfo &RegisterInfo, const MCInstrInfo &InstructionInfo);
+};
+} // namespace gematria
+
+#endif // THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_

--- a/gematria/datasets/basic_block_utils.h
+++ b/gematria/datasets/basic_block_utils.h
@@ -20,8 +20,8 @@
 #include <vector>
 
 #include "gematria/llvm/disassembler.h"
-#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
 
 namespace gematria {
 
@@ -29,11 +29,13 @@ using namespace llvm;
 
 // Basic Block Utilities.
 class BasicBlockUtils {
-public:
+ public:
   // Gets the registers used by a basic block (in the form of a sequence of
   // instructions).
-  static std::vector<unsigned> getUsedRegisters(const std::vector<DisassembledInstruction> &Instructions, const MCRegisterInfo &RegisterInfo, const MCInstrInfo &InstructionInfo);
+  static std::vector<unsigned> getUsedRegisters(
+      const std::vector<DisassembledInstruction> &Instructions,
+      const MCRegisterInfo &RegisterInfo, const MCInstrInfo &InstructionInfo);
 };
-} // namespace gematria
+}  // namespace gematria
 
-#endif // THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_
+#endif  // THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_

--- a/gematria/datasets/basic_block_utils_test.cc
+++ b/gematria/datasets/basic_block_utils_test.cc
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "X86.h"
+#include "X86InstrInfo.h"
+#include "X86RegisterInfo.h"
 #include "gematria/datasets/basic_block_utils.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/llvm/asm_parser.h"
@@ -20,20 +23,22 @@
 
 #include "gtest/gtest.h"
 
+using testing::UnorderedElementsAre;
+
 namespace gematria {
 namespace {
 class BasicBlockUtilsTest : public ::testing::Test {
 private:
-  static std::unique_ptr<LlvmArchitectureSupport> LlvmArchSupport;
+  inline static std::unique_ptr<LlvmArchitectureSupport> LlvmArchSupport;
 
 protected:
   static void SetUpTestSuite() {
     LlvmArchSupport = LlvmArchitectureSupport::X86_64();
   }
 
-  std::vector<DisassembledInstruction> getInstructions(std::string_view textual_assembly) {
+  std::vector<DisassembledInstruction> getInstructions(std::string_view TextualAssembly) {
     auto MCInstsOrError = gematria::ParseAsmCodeFromString(LlvmArchSupport->target_machine(),
-        textual_assembly, llvm::InlineAsm::AsmDialect::AD_ATT);
+        TextualAssembly, llvm::InlineAsm::AsmDialect::AD_ATT);
     CHECK_OK(MCInstsOrError);
 
     std::vector<DisassembledInstruction> Instructions;
@@ -45,15 +50,47 @@ protected:
     return Instructions;
   }
 
-  std::vector<unsigned> getUsedRegisters(std::string_view textual_assembly) {
-    return BasicBlockUtils::getUsedRegisters(getInstructions(textual_assembly),
+  std::vector<unsigned> getUsedRegisters(std::string_view TextualAssembly) {
+    return BasicBlockUtils::getUsedRegisters(getInstructions(TextualAssembly),
         LlvmArchSupport->mc_register_info(), LlvmArchSupport->mc_instr_info());
   }
 };
 
-TEST_F(BasicBlockUtilsTest, GetUsedRegisters) {
-  //std::vector<unsigned> UsedRegisters = BasicBlockUtils::GetUsedRegisters({});
-  EXPECT_EQ({}, 0);
+TEST_F(BasicBlockUtilsTest, UsedRegistersSingleRegister) {
+  std::vector<unsigned> UsedRegisters = getUsedRegisters(R"asm(
+    mov $0, %rax
+  )asm");
+  EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::RAX));
+}
+
+TEST_F(BasicBlockUtilsTest, UsedRegistersSubRegister) {
+  std::vector<unsigned> UsedRegisters = getUsedRegisters(R"asm(
+    mov $0, %al
+    mov $0, %ax
+    mov $0, %rax
+  )asm");
+  EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::RAX));
+}
+
+TEST_F(BasicBlockUtilsTest, UsedRegistersMultipleRegisters) {
+  std::vector<unsigned> UsedRegisters = getUsedRegisters(R"asm(
+    movq %rax, %rcx
+    movq %rdx, %rbx
+    movq %rsi, %rdi
+    movq %rsp, %rbp
+    movq %r8, %r9
+    movq %r10, %r11
+    movq %r12, %r13
+    movq %r14, %r15
+  )asm");
+  EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::RAX, X86::RCX, X86::RDX, X86::RBX, X86::RSI, X86::RDI, X86::RSP, X86::RBP, X86::R8, X86::R9, X86::R10, X86::R11, X86::R12, X86::R13, X86::R14, X86::R15));
+}
+
+TEST_F(BasicBlockUtilsTest, UsedRegistersVectorRegisters) {
+  std::vector<unsigned> UsedRegisters = getUsedRegisters(R"asm(
+    vmovapd %zmm1, %zmm2
+  )asm");
+  EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::ZMM1, X86::ZMM2));
 }
 
 } //namespace

--- a/gematria/datasets/basic_block_utils_test.cc
+++ b/gematria/datasets/basic_block_utils_test.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "gematria/datasets/basic_block_utils.h"
+
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86RegisterInfo.h"
-#include "gematria/datasets/basic_block_utils.h"
-#include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/disassembler.h"
+#include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/testing/matchers.h"
-
 #include "gtest/gtest.h"
 
 using testing::UnorderedElementsAre;
@@ -28,17 +28,19 @@ using testing::UnorderedElementsAre;
 namespace gematria {
 namespace {
 class BasicBlockUtilsTest : public ::testing::Test {
-private:
+ private:
   inline static std::unique_ptr<LlvmArchitectureSupport> LlvmArchSupport;
 
-protected:
+ protected:
   static void SetUpTestSuite() {
     LlvmArchSupport = LlvmArchitectureSupport::X86_64();
   }
 
-  std::vector<DisassembledInstruction> getInstructions(std::string_view TextualAssembly) {
-    auto MCInstsOrError = gematria::ParseAsmCodeFromString(LlvmArchSupport->target_machine(),
-        TextualAssembly, llvm::InlineAsm::AsmDialect::AD_ATT);
+  std::vector<DisassembledInstruction> getInstructions(
+      std::string_view TextualAssembly) {
+    auto MCInstsOrError = gematria::ParseAsmCodeFromString(
+        LlvmArchSupport->target_machine(), TextualAssembly,
+        llvm::InlineAsm::AsmDialect::AD_ATT);
     CHECK_OK(MCInstsOrError);
 
     std::vector<DisassembledInstruction> Instructions;
@@ -51,8 +53,9 @@ protected:
   }
 
   std::vector<unsigned> getUsedRegisters(std::string_view TextualAssembly) {
-    return BasicBlockUtils::getUsedRegisters(getInstructions(TextualAssembly),
-        LlvmArchSupport->mc_register_info(), LlvmArchSupport->mc_instr_info());
+    return BasicBlockUtils::getUsedRegisters(
+        getInstructions(TextualAssembly), LlvmArchSupport->mc_register_info(),
+        LlvmArchSupport->mc_instr_info());
   }
 };
 
@@ -83,7 +86,11 @@ TEST_F(BasicBlockUtilsTest, UsedRegistersMultipleRegisters) {
     movq %r12, %r13
     movq %r14, %r15
   )asm");
-  EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::RAX, X86::RCX, X86::RDX, X86::RBX, X86::RSI, X86::RDI, X86::RSP, X86::RBP, X86::R8, X86::R9, X86::R10, X86::R11, X86::R12, X86::R13, X86::R14, X86::R15));
+  EXPECT_THAT(UsedRegisters,
+              UnorderedElementsAre(X86::RAX, X86::RCX, X86::RDX, X86::RBX,
+                                   X86::RSI, X86::RDI, X86::RSP, X86::RBP,
+                                   X86::R8, X86::R9, X86::R10, X86::R11,
+                                   X86::R12, X86::R13, X86::R14, X86::R15));
 }
 
 TEST_F(BasicBlockUtilsTest, UsedRegistersVectorRegisters) {
@@ -93,5 +100,5 @@ TEST_F(BasicBlockUtilsTest, UsedRegistersVectorRegisters) {
   EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::ZMM1, X86::ZMM2));
 }
 
-} //namespace
-} // namespace gematria
+}  // namespace
+}  // namespace gematria

--- a/gematria/datasets/basic_block_utils_test.cc
+++ b/gematria/datasets/basic_block_utils_test.cc
@@ -1,0 +1,60 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/basic_block_utils.h"
+#include "gematria/llvm/llvm_architecture_support.h"
+#include "gematria/llvm/asm_parser.h"
+#include "gematria/llvm/disassembler.h"
+#include "gematria/testing/matchers.h"
+
+#include "gtest/gtest.h"
+
+namespace gematria {
+namespace {
+class BasicBlockUtilsTest : public ::testing::Test {
+private:
+  static std::unique_ptr<LlvmArchitectureSupport> LlvmArchSupport;
+
+protected:
+  static void SetUpTestSuite() {
+    LlvmArchSupport = LlvmArchitectureSupport::X86_64();
+  }
+
+  std::vector<DisassembledInstruction> getInstructions(std::string_view textual_assembly) {
+    auto MCInstsOrError = gematria::ParseAsmCodeFromString(LlvmArchSupport->target_machine(),
+        textual_assembly, llvm::InlineAsm::AsmDialect::AD_ATT);
+    CHECK_OK(MCInstsOrError);
+
+    std::vector<DisassembledInstruction> Instructions;
+    Instructions.reserve(MCInstsOrError->size());
+
+    for (MCInst Instruction : *MCInstsOrError)
+      Instructions.push_back({0, "", "", Instruction});
+
+    return Instructions;
+  }
+
+  std::vector<unsigned> getUsedRegisters(std::string_view textual_assembly) {
+    return BasicBlockUtils::getUsedRegisters(getInstructions(textual_assembly),
+        LlvmArchSupport->mc_register_info(), LlvmArchSupport->mc_instr_info());
+  }
+};
+
+TEST_F(BasicBlockUtilsTest, GetUsedRegisters) {
+  //std::vector<unsigned> UsedRegisters = BasicBlockUtils::GetUsedRegisters({});
+  EXPECT_EQ({}, 0);
+}
+
+} //namespace
+} // namespace gematria


### PR DESCRIPTION
This patch adds a new `basic_block_utils` library that will be extended in subsequent patches to add additional functionality necessary for processing datasets of basic blocks. Currently, `BasicBlockUtils::getUsedRegisters` is implemented for #51.