### PR TITLE
Error out if we try to annotate a zero address

### DIFF
--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -143,16 +143,23 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     if (!std::get<0>(BenchmarkResultOrErr).isA<SnippetSegmentationFault>())
       return std::move(std::get<0>(BenchmarkResultOrErr));
 
-    handleAllErrors(std::move(std::get<0>(BenchmarkResultOrErr)),
-                    [&](SnippetSegmentationFault &CrashInfo) {
-                      MemoryMapping MemMap;
-                      // Zero out the last twelve bits of the address to align
-                      // the address to a page boundary.
-                      uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
-                      MemMap.Address = MapAddress;
-                      MemMap.MemoryValueName = "memdef1";
-                      BenchCode.Key.MemoryMappings.push_back(MemMap);
-                    });
+    Error AnnotationError = handleErrors(
+        std::move(std::get<0>(BenchmarkResultOrErr)),
+        [&](SnippetSegmentationFault &CrashInfo) -> Error {
+          MemoryMapping MemMap;
+          // Zero out the last twelve bits of the address to align
+          // the address to a page boundary.
+          uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
+          if (MapAddress == 0)
+            return make_error<Failure>("Segfault at zero address, cannot map.");
+          MemMap.Address = MapAddress;
+          MemMap.MemoryValueName = "memdef1";
+          BenchCode.Key.MemoryMappings.push_back(MemMap);
+
+          return Error::success();
+        });
+
+    if (AnnotationError) return std::move(AnnotationError);
   }
 
   MemAnnotations.accessed_blocks.reserve(BenchCode.Key.MemoryMappings.size());

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -113,5 +113,13 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisNotPageAligned) {
   EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
 }
 
+TEST_F(FindAccessedAddrsExegesisTest, ExegesisZeroAddressError) {
+  auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
+    movq $0x0, %rax
+    movq (%rax), %rax
+  )asm");
+  ASSERT_FALSE(static_cast<bool>(AddrsOrErr));
+}
+
 }  // namespace
 }  // namespace gematria


### PR DESCRIPTION
This patch makes the exegesis annotator error out if we try to map the zero address as we are not able to do this with mmap. To solve this while still being able to annotate the blocks, we probably need some way to adjust the register/memory values.