### PR TITLE
Make exegesis annotator error out when remapping an address

### DIFF
--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -152,6 +152,9 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
           uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
           if (MapAddress == 0)
             return make_error<Failure>("Segfault at zero address, cannot map.");
+          // TODO(boomanaiden154): The fault captured below occurs when
+	  // exegesis tries to map an address and the mmap fails. When these
+	  // errors are handled within exegesis, we should remove this check.
           for (const auto &MemoryMapping : BenchCode.Key.MemoryMappings) {
             if (MemoryMapping.Address == MapAddress)
               return make_error<Failure>(

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -152,6 +152,11 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
           uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
           if (MapAddress == 0)
             return make_error<Failure>("Segfault at zero address, cannot map.");
+          for (const auto &MemoryMapping : BenchCode.Key.MemoryMappings) {
+            if (MemoryMapping.Address == MapAddress)
+              return make_error<Failure>(
+                  "Segfault at an address already mapped.");
+          }
           MemMap.Address = MapAddress;
           MemMap.MemoryValueName = "memdef1";
           BenchCode.Key.MemoryMappings.push_back(MemMap);

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -143,16 +143,23 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     if (!std::get<0>(BenchmarkResultOrErr).isA<SnippetSegmentationFault>())
       return std::move(std::get<0>(BenchmarkResultOrErr));
 
-    handleAllErrors(std::move(std::get<0>(BenchmarkResultOrErr)),
-                    [&](SnippetSegmentationFault &CrashInfo) {
-                      MemoryMapping MemMap;
-                      // Zero out the last twelve bits of the address to align
-                      // the address to a page boundary.
-                      uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
-                      MemMap.Address = MapAddress;
-                      MemMap.MemoryValueName = "memdef1";
-                      BenchCode.Key.MemoryMappings.push_back(MemMap);
-                    });
+    Error AnnotationError = handleErrors(
+        std::move(std::get<0>(BenchmarkResultOrErr)),
+        [&](SnippetSegmentationFault &CrashInfo) -> Error {
+          MemoryMapping MemMap;
+          // Zero out the last twelve bits of the address to align
+          // the address to a page boundary.
+          uintptr_t MapAddress = (CrashInfo.getAddress() & ~0xfff);
+          if (MapAddress == 0)
+            return make_error<Failure>("Segfault at zero address, cannot map.");
+          MemMap.Address = MapAddress;
+          MemMap.MemoryValueName = "memdef1";
+          BenchCode.Key.MemoryMappings.push_back(MemMap);
+
+          return Error::success();
+        });
+
+    if (AnnotationError) return std::move(AnnotationError);
   }
 
   MemAnnotations.accessed_blocks.reserve(BenchCode.Key.MemoryMappings.size());

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -153,8 +153,8 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
           if (MapAddress == 0)
             return make_error<Failure>("Segfault at zero address, cannot map.");
           // TODO(boomanaiden154): The fault captured below occurs when
-	  // exegesis tries to map an address and the mmap fails. When these
-	  // errors are handled within exegesis, we should remove this check.
+          // exegesis tries to map an address and the mmap fails. When these
+          // errors are handled within exegesis, we should remove this check.
           for (const auto &MemoryMapping : BenchCode.Key.MemoryMappings) {
             if (MemoryMapping.Address == MapAddress)
               return make_error<Failure>(

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -121,5 +121,17 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisZeroAddressError) {
   ASSERT_FALSE(static_cast<bool>(AddrsOrErr));
 }
 
+TEST_F(FindAccessedAddrsExegesisTest, ExegesisMultipleSameAddressError) {
+  // Try and load memory from an address above the current user space address
+  // space ceiling (assuming five level page tables are not enabled) as the
+  // script will currently try and annotate this, but exegesis will fail
+  // to map the address when it attempts to.
+  auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
+    movabsq $0x0000800000000000, %rax
+    movq (%rax), %rax
+  )asm");
+  ASSERT_FALSE(static_cast<bool>(AddrsOrErr));
+}
+
 }  // namespace
 }  // namespace gematria

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -113,5 +113,13 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisNotPageAligned) {
   EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
 }
 
+TEST_F(FindAccessedAddrsExegesisTest, ExegesisZeroAddressError) {
+  auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
+    movq $0x0, %rax
+    movq (%rax), %rax
+  )asm");
+  ASSERT_FALSE(static_cast<bool>(AddrsOrErr));
+}
+
 }  // namespace
 }  // namespace gematria


### PR DESCRIPTION
Currently, there is a failure condition seen in some blocks where the annotator finds a segfault, tells exegesis to map a page there, and then the block fails again at the same address. This needs some debugging, but currently it will be helpful if we can just log a warning message and skip this basic block.