### PR TITLE
Add functionality to convert JSON datasets to Gematria protos.

### DIFF
--- a/gematria/datasets/BUILD
+++ b/gematria/datasets/BUILD
@@ -32,6 +32,24 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "json_importer",
+    srcs = ["json_importer.cc"],
+    hdrs = ["json_importer.h"],
+    visibility = ["//:internal_users"],
+    deps = [
+        "//gematria/datasets:bhive_importer",
+        "//gematria/llvm:canonicalizer",
+        "//gematria/llvm:llvm_to_absl",
+        "//gematria/proto:annotation_cc_proto",
+        "//gematria/proto:basic_block_cc_proto",
+        "//gematria/proto:throughput_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
 cc_test(
     name = "bhive_importer_test",
     size = "small",

--- a/gematria/datasets/json_importer.cc
+++ b/gematria/datasets/json_importer.cc
@@ -1,0 +1,111 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/json_importer.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "absl/status/statusor.h"
+#include "gematria/datasets/bhive_importer.h"
+#include "gematria/llvm/canonicalizer.h"
+#include "gematria/llvm/llvm_to_absl.h"
+#include "gematria/proto/annotation.pb.h"
+#include "gematria/proto/basic_block.pb.h"
+#include "gematria/proto/throughput.pb.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
+
+namespace gematria {
+
+JSONImporter::JSONImporter(const Canonicalizer* canonicalizer)
+    : bhive_importer_(std::make_unique<BHiveImporter>(canonicalizer)) {}
+
+absl::StatusOr<BasicBlockWithThroughputProto> JSONImporter::ParseJSON(
+    std::string_view source_name, std::string_view json_string,
+    double throughput_scaling /* = 1.0 */, uint64_t base_address /* = 0 */) {
+  llvm::Expected<llvm::json::Value> json_value =
+      llvm::json::parse(llvm::StringRef(json_string));
+  if (llvm::Error error = json_value.takeError()) {
+    return LlvmErrorToStatus(std::move(error));
+  }
+  llvm::json::Object* json_block = json_value->getAsObject();
+
+  std::optional<llvm::StringRef> machine_code_hex =
+      json_block->getString("machine_code_hex");
+  if (!machine_code_hex.has_value()) {
+    return absl::InvalidArgumentError(
+        "Basic block JSON is missing key `machine_code_hex`.");
+  }
+  BasicBlockWithThroughputProto proto;
+  absl::StatusOr<BasicBlockProto> block_proto_or_status =
+      bhive_importer_->BasicBlockProtoFromMachineCodeHex(*machine_code_hex,
+                                                         base_address);
+  if (!block_proto_or_status.ok()) return block_proto_or_status.status();
+  *proto.mutable_basic_block() = std::move(block_proto_or_status).value();
+
+  llvm::json::Array* json_annotations =
+      json_block->getArray("instruction_annotations");
+  auto instructions =
+      proto.mutable_basic_block()->mutable_canonicalized_instructions();
+  for (llvm::json::Value raw_json_annotation : *json_annotations) {
+    llvm::json::Object* json_annotation = raw_json_annotation.getAsObject();
+    std::optional<llvm::StringRef> annotation_name =
+        json_annotation->getString("name");
+    if (!annotation_name.has_value()) {
+      return absl::InvalidArgumentError(
+          "Basic block annotation JSON is missing key `name`.");
+    }
+    llvm::json::Array* json_annotation_values =
+        json_annotation->getArray("values");
+    if (json_annotation_values->size() !=
+        proto.basic_block().canonicalized_instructions_size()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Basic block annotation JSON does not have the same number of "
+          "annotation values as instructions for annotation name: ",
+          (*annotation_name).data()));
+    }
+    for (int i = 0; i < instructions->size(); ++i) {
+      std::optional<double> annotation_value =
+          (*json_annotation_values)[i].getAsNumber();
+      if (!annotation_value.has_value()) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Basic block annotation value JSON cannot be "
+            "intepreted as double for annotation name: ",
+            (*annotation_name).data(), " and instruction index: ", i));
+      }
+      AnnotationProto* annotation_proto =
+          (*instructions)[i].add_instruction_annotations();
+      annotation_proto->set_name(*annotation_name);
+      annotation_proto->set_value(*annotation_value);
+    }
+  }
+
+  std::optional<double> throughput_cycles = json_block->getNumber("throughput");
+  if (!throughput_cycles.has_value()) {
+    return absl::InvalidArgumentError(
+        "Basic block JSON is missing key `throughput`.");
+  }
+
+  ThroughputWithSourceProto& throughput = *proto.add_inverse_throughputs();
+  throughput.set_source(source_name);
+  throughput.add_inverse_throughput_cycles(*throughput_cycles *
+                                           throughput_scaling);
+
+  return proto;
+}
+
+}  // namespace gematria

--- a/gematria/datasets/json_importer.h
+++ b/gematria/datasets/json_importer.h
@@ -1,0 +1,67 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMATRIA_DATASETS_JSON_IMPORTER_H_
+#define GEMATRIA_DATASETS_JSON_IMPORTER_H_
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "absl/status/statusor.h"
+#include "gematria/datasets/bhive_importer.h"
+#include "gematria/llvm/canonicalizer.h"
+#include "gematria/proto/throughput.pb.h"
+
+namespace gematria {
+
+// Parser for JSON objects representing basic blocks.
+class JSONImporter {
+ public:
+  // Creates a new BHive importer from a given canonicalizer. The canonicalizer
+  // must be for the architecture/microarchitecture of the data set.
+  // Does not take ownership of the canonicalizer.
+  explicit JSONImporter(const Canonicalizer* canonicalizer);
+
+  // Parses JSON objects representing basic blocks, Expects that the JSON
+  // follows the format:
+  // {
+  //   "machine_code_hex": <machine_code_hex>,
+  //   "instruction_annotations": [
+  //     { "name": <annotation_type_name>,
+  //       "values": [<annotation_value>, ...] },
+  //     ...
+  //   ],
+  //   "throughput": <throughput>
+  // }
+  // where <machine_code_hex> is a hex string holding the machine code that the
+  // basic block is comprised of, <annotation_type_name> is a string holding the
+  // name of the type of annotation represented by this element of
+  // "instruction_annotations", <annotation_value> is a numeric value
+  // corresponding to the annotation type for the instruction sharing the same
+  // index, and <throughput> is the numeric inverse throughput of the basic
+  // block. Optionally applies `throughput_scaling` to the throughput value, and
+  // uses `base_address` as the address of the first instruction in the basic
+  // block.
+  absl::StatusOr<BasicBlockWithThroughputProto> ParseJSON(
+      std::string_view source_name, std::string_view json_string,
+      double throughput_scaling = 1.0, uint64_t base_address = 0);
+
+ private:
+  std::unique_ptr<BHiveImporter> bhive_importer_;
+};
+
+}  // namespace gematria
+
+#endif  // GEMATRIA_DATASETS_JSON_IMPORTER_H_

--- a/gematria/datasets/python/BUILD
+++ b/gematria/datasets/python/BUILD
@@ -29,6 +29,26 @@ gematria_pybind_extension(
     ],
 )
 
+gematria_pybind_extension(
+    name = "json_importer",
+    srcs = ["json_importer.cc"],
+    py_deps = [
+        "//gematria/llvm/python:canonicalizer",
+        "//gematria/proto:annotation_py_pb2",
+        "//gematria/proto:basic_block_py_pb2",
+        "//gematria/proto:canonicalized_instruction_py_pb2",
+        "//gematria/proto:throughput_py_pb2",
+    ],
+    visibility = ["//:internal_users"],
+    deps = [
+        "//gematria/datasets:json_importer",
+        "//gematria/llvm:canonicalizer",
+        "@com_google_pybind11_protobuf//pybind11_protobuf:native_proto_caster",
+        "@llvm-project//llvm:Support",
+        "@pybind11_abseil_repo//pybind11_abseil:status_casters",
+    ],
+)
+
 gematria_py_test(
     name = "bhive_importer_test",
     size = "small",
@@ -37,6 +57,21 @@ gematria_py_test(
         ":bhive_importer",
         "//gematria/llvm/python:canonicalizer",
         "//gematria/llvm/python:llvm_architecture_support",
+        "//gematria/proto:basic_block_py_pb2",
+        "//gematria/proto:canonicalized_instruction_py_pb2",
+        "//gematria/proto:throughput_py_pb2",
+    ],
+)
+
+gematria_py_test(
+    name = "json_importer_test",
+    size = "small",
+    srcs = ["json_importer_test.py"],
+    deps = [
+        ":json_importer",
+        "//gematria/llvm/python:canonicalizer",
+        "//gematria/llvm/python:llvm_architecture_support",
+        "//gematria/proto:annotation_py_pb2",
         "//gematria/proto:basic_block_py_pb2",
         "//gematria/proto:canonicalized_instruction_py_pb2",
         "//gematria/proto:throughput_py_pb2",

--- a/gematria/datasets/python/json_importer.cc
+++ b/gematria/datasets/python/json_importer.cc
@@ -1,0 +1,92 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/json_importer.h"
+
+#include <cstdint>
+#include <string_view>
+
+#include "gematria/llvm/canonicalizer.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "pybind11/cast.h"
+#include "pybind11/detail/common.h"
+#include "pybind11/pybind11.h"
+#include "pybind11_abseil/import_status_module.h"
+#include "pybind11_abseil/status_casters.h"
+#include "pybind11_protobuf/native_proto_caster.h"
+
+namespace gematria {
+
+namespace py = ::pybind11;
+
+PYBIND11_MODULE(json_importer, m) {
+  m.doc() = "Support code for importing data from a JSON format.";
+
+  py::google::ImportStatusModule();
+
+  py::class_<JSONImporter>(m, "JsonImporter")
+      .def(  //
+          py::init<const Canonicalizer* /* canonicalizer */>(),
+          py::arg("canonicalizer"),
+          R"(Initializes a new JSON importer for a given architecture.
+
+          Args:
+            canonicalizer: The canonicalizer used to disassemble instructions
+              and convert them to the Gematria proto representation.)")
+      .def(  //
+          "basic_block_with_throughput_proto_from_json_object",
+          &JSONImporter::ParseJSON, py::arg("source_name"),
+          py::arg("json_string"), py::arg("throughput_scaling") = 1.0,
+          py::arg("base_address") = uint64_t{0},
+          R"(Creates a BasicBlockWithThroughputProto from a JSON object.
+
+          Takes a JSON string in the format:
+          {
+            "machine_code_hex": <machine_code_hex>,
+            "instruction_annotations": [
+              { "name": <annotation_type_name>,
+                "values": [<annotation_value>, ...] },
+              ...
+            ],
+            "throughput": <throughput>
+          }
+          where <machine_code_hex> is a hex string holding the machine code that
+          the basic block is comprised of, <annotation_type_name> is a string
+          holding the name of the type of annotation represented by this element
+          of "instruction_annotations", <annotation_value> is a numeric value
+          corresponding to the annotation type for the instruction sharing the
+          same index, and <throughput> is the numeric inverse throughput of the
+          basic block. 
+
+          Args:
+            source_name: The name of the throughput source used in the output
+              proto.
+            json_string: The JSON object representing a basic block.
+            throughput_column_index: The index of the column in the CSV
+              containing the throughput in cycles.
+            throughput_scaling: An optional scaling applied to {throughput}.
+            base_address: The address of the first instruction of the basic
+              block.
+
+          Returns:
+            A BasicBlockWithThroughputProto that contains the basic block
+            extracted from {machine_code}, and one throughput information based
+            on {throughput}.
+
+          Raises:
+            StatusNotOk: When parsing the JSON string or extracting data from the
+              machine code fails.)");
+}
+
+}  // namespace gematria

--- a/gematria/datasets/python/json_importer_test.py
+++ b/gematria/datasets/python/json_importer_test.py
@@ -1,0 +1,209 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from gematria.datasets.python import json_importer
+from gematria.llvm.python import canonicalizer
+from gematria.llvm.python import llvm_architecture_support
+from gematria.proto import annotation_pb2
+from gematria.proto import basic_block_pb2
+from gematria.proto import canonicalized_instruction_pb2
+from gematria.proto import throughput_pb2
+
+_CanonicalizedOperandProto = (
+    canonicalized_instruction_pb2.CanonicalizedOperandProto
+)
+_CanonicalizedInstructionProto = (
+    canonicalized_instruction_pb2.CanonicalizedInstructionProto
+)
+_AnnotationProto = annotation_pb2.AnnotationProto
+
+# A basic block that can be obtained by disassembling the basic block
+# "4829d38b44246c8b54246848c1fb034829d04839c3" and using base_address=600.
+_EXPECTED_BASIC_BLOCK_PROTO = basic_block_pb2.BasicBlockProto(
+    machine_instructions=(
+        basic_block_pb2.MachineInstructionProto(
+            assembly="\tsubq\t%rdx, %rbx",
+            machine_code=b"H)\323",
+            address=600,
+        ),
+        basic_block_pb2.MachineInstructionProto(
+            assembly="\tmovl\t108(%rsp), %eax",
+            machine_code=b"\213D$l",
+            address=603,
+        ),
+        basic_block_pb2.MachineInstructionProto(
+            assembly="\tmovl\t104(%rsp), %edx",
+            machine_code=b"\213T$h",
+            address=607,
+        ),
+        basic_block_pb2.MachineInstructionProto(
+            assembly="\tsarq\t$3, %rbx",
+            machine_code=b"H\301\373\003",
+            address=611,
+        ),
+        basic_block_pb2.MachineInstructionProto(
+            assembly="\tsubq\t%rdx, %rax",
+            machine_code=b"H)\320",
+            address=615,
+        ),
+        basic_block_pb2.MachineInstructionProto(
+            assembly="\tcmpq\t%rax, %rbx",
+            machine_code=b"H9\303",
+            address=618,
+        ),
+    ),
+    canonicalized_instructions=(
+        _CanonicalizedInstructionProto(
+            mnemonic="SUB",
+            llvm_mnemonic="SUB64rr",
+            output_operands=(_CanonicalizedOperandProto(register_name="RBX"),),
+            input_operands=(
+                _CanonicalizedOperandProto(register_name="RBX"),
+                _CanonicalizedOperandProto(register_name="RDX"),
+            ),
+            implicit_output_operands=(
+                _CanonicalizedOperandProto(register_name="EFLAGS"),
+            ),
+            instruction_annotations=(
+                _AnnotationProto(name="cache_miss_freq", value=0.0),
+            ),
+        ),
+        _CanonicalizedInstructionProto(
+            mnemonic="MOV",
+            llvm_mnemonic="MOV32rm",
+            output_operands=(_CanonicalizedOperandProto(register_name="EAX"),),
+            input_operands=(
+                _CanonicalizedOperandProto(
+                    memory=_CanonicalizedOperandProto.MemoryLocation(
+                        alias_group_id=1
+                    )
+                ),
+                _CanonicalizedOperandProto(
+                    address=_CanonicalizedOperandProto.AddressTuple(
+                        base_register="RSP", displacement=108, scaling=1
+                    )
+                ),
+            ),
+            instruction_annotations=(
+                _AnnotationProto(name="cache_miss_freq", value=0.9),
+            ),
+        ),
+        _CanonicalizedInstructionProto(
+            mnemonic="MOV",
+            llvm_mnemonic="MOV32rm",
+            output_operands=(_CanonicalizedOperandProto(register_name="EDX"),),
+            input_operands=(
+                _CanonicalizedOperandProto(
+                    memory=_CanonicalizedOperandProto.MemoryLocation(
+                        alias_group_id=1
+                    )
+                ),
+                _CanonicalizedOperandProto(
+                    address=_CanonicalizedOperandProto.AddressTuple(
+                        base_register="RSP", displacement=104, scaling=1
+                    )
+                ),
+            ),
+            instruction_annotations=(
+                _AnnotationProto(name="cache_miss_freq", value=0.875),
+            ),
+        ),
+        _CanonicalizedInstructionProto(
+            mnemonic="SAR",
+            llvm_mnemonic="SAR64ri",
+            output_operands=(_CanonicalizedOperandProto(register_name="RBX"),),
+            input_operands=(
+                _CanonicalizedOperandProto(register_name="RBX"),
+                _CanonicalizedOperandProto(immediate_value=3),
+            ),
+            implicit_output_operands=(
+                _CanonicalizedOperandProto(register_name="EFLAGS"),
+            ),
+            instruction_annotations=(
+                _AnnotationProto(name="cache_miss_freq", value=0.01),
+            ),
+        ),
+        _CanonicalizedInstructionProto(
+            mnemonic="SUB",
+            llvm_mnemonic="SUB64rr",
+            output_operands=(_CanonicalizedOperandProto(register_name="RAX"),),
+            input_operands=(
+                _CanonicalizedOperandProto(register_name="RAX"),
+                _CanonicalizedOperandProto(register_name="RDX"),
+            ),
+            implicit_output_operands=(
+                _CanonicalizedOperandProto(register_name="EFLAGS"),
+            ),
+            instruction_annotations=(
+                _AnnotationProto(name="cache_miss_freq", value=0.0),
+            ),
+        ),
+        _CanonicalizedInstructionProto(
+            mnemonic="CMP",
+            llvm_mnemonic="CMP64rr",
+            input_operands=(
+                _CanonicalizedOperandProto(register_name="RBX"),
+                _CanonicalizedOperandProto(register_name="RAX"),
+            ),
+            implicit_output_operands=(
+                _CanonicalizedOperandProto(register_name="EFLAGS"),
+            ),
+            instruction_annotations=(
+                _AnnotationProto(name="cache_miss_freq", value=0.1),
+            ),
+        ),
+    ),
+)
+
+
+class JsonImporterTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+
+    self._x86_llvm = llvm_architecture_support.LlvmArchitectureSupport.x86_64()
+    self._x86_canonicalizer = canonicalizer.Canonicalizer.x86_64(self._x86_llvm)
+
+  def test_x86_parse_json_object(self):
+    source_name = "test: made-up"
+    importer = json_importer.JsonImporter(self._x86_canonicalizer)
+    block_proto = importer.basic_block_with_throughput_proto_from_json_object(
+        source_name=source_name,
+        json_string=r"""{
+          "machine_code_hex": "4829d38b44246c8b54246848c1fb034829d04839c3",
+          "instruction_annotations": [
+            { "name": "cache_miss_freq", "values": [0.0, 0.9, 0.875, 0.01, 0.0, 0.1] }
+          ],
+          "throughput": 10
+        }""",
+        base_address=600,
+        throughput_scaling=2.0,
+    )
+    self.assertEqual(
+        block_proto,
+        throughput_pb2.BasicBlockWithThroughputProto(
+            basic_block=_EXPECTED_BASIC_BLOCK_PROTO,
+            inverse_throughputs=(
+                throughput_pb2.ThroughputWithSourceProto(
+                    source=source_name,
+                    inverse_throughput_cycles=[20.0],
+                ),
+            ),
+        ),
+    )
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
 * JSON datasets, while not very useful otherwise, being easy to read are handy for debugging while also being rich enough to store extra, possibly nested, data such as instruction annotations.
 * Note: the current JSON format includes instruction annotations and so depends on `AnnotationProto` from #27, and will not build without `gematria/proto/annotation.proto`.