### PR TITLE
Bump LLVM version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,9 +165,9 @@ new_git_repository(
 
 # LLVM and its dependencies
 
-LLVM_COMMIT = "31ab2c4f616d686c06e9b573c8f1a4ae7ad2d8c3"
+LLVM_COMMIT = "718fbbef5f18a2b7e7fc4f842b1452ae9bee581a"
 
-LLVM_SHA256 = "4d2ed1cd8f1ce8b1a41002dfcac0ff0f12f0734cc5161192deecd5513e873af5"
+LLVM_SHA256 = "e17b455b320e5c09acecadf2fb0f9ce471d6668382569132d2c7f144ca10bafa"
 
 http_archive(
     name = "llvm-raw",

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -69,7 +69,7 @@ Expected<std::unique_ptr<ExegesisAnnotator>> ExegesisAnnotator::create(
 
   std::unique_ptr<const SnippetRepetitor> SnipRepetitor =
       SnippetRepetitor::Create(Benchmark::RepetitionModeE::Duplicate,
-                               ExegesisState);
+                               ExegesisState, X86::R8);
 
   return std::unique_ptr<ExegesisAnnotator>(new ExegesisAnnotator(
       ExegesisState, std::move(*RunnerOrErr), std::move(SnipRepetitor)));
@@ -124,8 +124,8 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
   }
 
   while (true) {
-    std::unique_ptr<const SnippetRepetitor> SR =
-        SnippetRepetitor::Create(Benchmark::RepetitionModeE::Duplicate, State);
+    std::unique_ptr<const SnippetRepetitor> SR = SnippetRepetitor::Create(
+        Benchmark::RepetitionModeE::Duplicate, State, X86::R8);
     Expected<BenchmarkRunner::RunnableConfiguration> RCOrErr =
         Runner->getRunnableConfiguration(BenchCode, 10000, 0, *SR);
 


### PR DESCRIPTION
This patch bumps the LLVM version, fixes associated fallout, and fixes issue #76 with an llvm-exegesis patch (https://github.com/llvm/llvm-project/pull/86069).