### PR TITLE
Add instruction annotations to the basic block representations.

### DIFF
--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -218,6 +218,31 @@ class InstructionOperand {
 
 std::ostream& operator<<(std::ostream& os, const InstructionOperand& operand);
 
+// Represents an annotation holding a value such as some measure/statistic
+// paired with the instruction.
+struct Annotation {
+  Annotation() : value(-1){};
+
+  // Initializes all fields of the annotation.
+  Annotation(std::string name, double value);
+
+  Annotation(const Annotation&) = default;
+  Annotation(Annotation&&) = default;
+
+  Annotation& operator=(const Annotation&) = default;
+  Annotation& operator=(Annotation&&) = default;
+
+  bool operator==(const Annotation& other) const;
+  bool operator!=(const Annotation& other) const { return !(*this == other); }
+
+  std::string ToString() const;
+
+  std::string name;
+  double value;
+};
+
+std::ostream& operator<<(std::ostream& os, const Annotation& annotation);
+
 // Represents a single instruction.
 struct Instruction {
   Instruction() {}
@@ -229,7 +254,9 @@ struct Instruction {
               std::vector<InstructionOperand> input_operands,
               std::vector<InstructionOperand> implicit_input_operands,
               std::vector<InstructionOperand> output_operands,
-              std::vector<InstructionOperand> implicit_output_operands);
+              std::vector<InstructionOperand> implicit_output_operands,
+              std::vector<Annotation> instruction_annotations =
+                  std::vector<Annotation>{});
 
   Instruction(const Instruction&) = default;
   Instruction(Instruction&&) = default;
@@ -279,6 +306,11 @@ struct Instruction {
   // machine learning task easier, we present also the explicit output operands
   // to the ML models explicitly.
   std::vector<InstructionOperand> implicit_output_operands;
+
+  // The list of instruction level annotations used to supply additional
+  // information to the model. Currently includes the cache miss frequency of
+  // the instruction. Used to better model the overhead coming from LLC misses.
+  std::vector<Annotation> instruction_annotations;
 
   // The address of the instruction.
   uint64_t address = 0;

--- a/gematria/basic_block/basic_block_protos.cc
+++ b/gematria/basic_block/basic_block_protos.cc
@@ -20,10 +20,36 @@
 #include <vector>
 
 #include "gematria/basic_block/basic_block.h"
+#include "gematria/proto/annotation.pb.h"
 #include "gematria/proto/canonicalized_instruction.pb.h"
 #include "google/protobuf/repeated_ptr_field.h"
 
 namespace gematria {
+
+namespace {
+
+template <typename Object, typename Proto, typename Convertor>
+std::vector<Object> ToVector(
+    const google::protobuf::RepeatedPtrField<Proto>& protos,
+    Convertor object_from_proto) {
+  std::vector<Object> result(protos.size());
+  std::transform(protos.begin(), protos.end(), result.begin(),
+                 object_from_proto);
+  return result;
+}
+
+template <typename Object, typename Proto, typename Convertor>
+void ToRepeatedPtrField(
+    const std::vector<Object>& objects,
+    google::protobuf::RepeatedPtrField<Proto>* repeated_field,
+    Convertor proto_from_object) {
+  repeated_field->Reserve(objects.size());
+  std::transform(objects.begin(), objects.end(),
+                 google::protobuf::RepeatedFieldBackInserter(repeated_field),
+                 proto_from_object);
+}
+
+}  // namespace
 
 AddressTuple AddressTupleFromProto(
     const CanonicalizedOperandProto::AddressTuple& proto) {
@@ -91,28 +117,18 @@ CanonicalizedOperandProto ProtoFromInstructionOperand(
   return proto;
 }
 
-namespace {
-
-std::vector<InstructionOperand> ToVector(
-    const google::protobuf::RepeatedPtrField<CanonicalizedOperandProto>&
-        protos) {
-  std::vector<InstructionOperand> result(protos.size());
-  std::transform(protos.begin(), protos.end(), result.begin(),
-                 InstructionOperandFromProto);
-  return result;
+Annotation AnnotationFromProto(const AnnotationProto& proto) {
+  return Annotation(
+      /* name = */ proto.name(),
+      /* value = */ proto.value());
 }
 
-void ToRepeatedPtrField(
-    const std::vector<InstructionOperand>& operands,
-    google::protobuf::RepeatedPtrField<CanonicalizedOperandProto>*
-        repeated_field) {
-  repeated_field->Reserve(operands.size());
-  std::transform(operands.begin(), operands.end(),
-                 google::protobuf::RepeatedFieldBackInserter(repeated_field),
-                 ProtoFromInstructionOperand);
+AnnotationProto ProtoFromAnnotation(const Annotation& annotation) {
+  AnnotationProto proto;
+  proto.set_name(annotation.name);
+  proto.set_value(annotation.value);
+  return proto;
 }
-
-}  // namespace
 
 Instruction InstructionFromProto(const CanonicalizedInstructionProto& proto) {
   return Instruction(
@@ -121,11 +137,21 @@ Instruction InstructionFromProto(const CanonicalizedInstructionProto& proto) {
       /* prefixes = */
       std::vector<std::string>(proto.prefixes().begin(),
                                proto.prefixes().end()),
-      /* input_operands = */ ToVector(proto.input_operands()),
-      /* implicit_input_operands = */ ToVector(proto.implicit_input_operands()),
-      /* output_operands = */ ToVector(proto.output_operands()),
+      /* input_operands = */
+      ToVector<InstructionOperand>(proto.input_operands(),
+                                   InstructionOperandFromProto),
+      /* implicit_input_operands = */
+      ToVector<InstructionOperand>(proto.implicit_input_operands(),
+                                   InstructionOperandFromProto),
+      /* output_operands = */
+      ToVector<InstructionOperand>(proto.output_operands(),
+                                   InstructionOperandFromProto),
       /* implicit_output_operands = */
-      ToVector(proto.implicit_output_operands()));
+      ToVector<InstructionOperand>(proto.implicit_output_operands(),
+                                   InstructionOperandFromProto),
+      /* instruction_annotations = */
+      ToVector<Annotation>(proto.instruction_annotations(),
+                           AnnotationFromProto));
 }
 
 CanonicalizedInstructionProto ProtoFromInstruction(
@@ -135,33 +161,27 @@ CanonicalizedInstructionProto ProtoFromInstruction(
   proto.set_llvm_mnemonic(instruction.llvm_mnemonic);
   proto.mutable_prefixes()->Assign(instruction.prefixes.begin(),
                                    instruction.prefixes.end());
-  ToRepeatedPtrField(instruction.input_operands,
-                     proto.mutable_input_operands());
+  ToRepeatedPtrField(instruction.input_operands, proto.mutable_input_operands(),
+                     ProtoFromInstructionOperand);
   ToRepeatedPtrField(instruction.implicit_input_operands,
-                     proto.mutable_implicit_input_operands());
+                     proto.mutable_implicit_input_operands(),
+                     ProtoFromInstructionOperand);
   ToRepeatedPtrField(instruction.output_operands,
-                     proto.mutable_output_operands());
+                     proto.mutable_output_operands(),
+                     ProtoFromInstructionOperand);
   ToRepeatedPtrField(instruction.implicit_output_operands,
-                     proto.mutable_implicit_output_operands());
+                     proto.mutable_implicit_output_operands(),
+                     ProtoFromInstructionOperand);
+  ToRepeatedPtrField(instruction.instruction_annotations,
+                     proto.mutable_instruction_annotations(),
+                     ProtoFromAnnotation);
   return proto;
 }
 
-namespace {
-
-std::vector<Instruction> ToVector(
-    const google::protobuf::RepeatedPtrField<CanonicalizedInstructionProto>&
-        protos) {
-  std::vector<Instruction> result(protos.size());
-  std::transform(protos.begin(), protos.end(), result.begin(),
-                 InstructionFromProto);
-  return result;
-}
-
-}  // namespace
-
 BasicBlock BasicBlockFromProto(const BasicBlockProto& proto) {
   return BasicBlock(
-      /* instructions = */ ToVector(proto.canonicalized_instructions()));
+      /* instructions = */ ToVector<Instruction>(
+          proto.canonicalized_instructions(), InstructionFromProto));
 }
 
 }  // namespace gematria

--- a/gematria/basic_block/basic_block_protos.cc
+++ b/gematria/basic_block/basic_block_protos.cc
@@ -32,8 +32,8 @@ template <typename Object, typename Proto, typename Convertor>
 std::vector<Object> ToVector(
     const google::protobuf::RepeatedPtrField<Proto>& protos,
     Convertor object_from_proto) {
-  std::vector<Object> result(protos.size());
-  std::transform(protos.begin(), protos.end(), result.begin(),
+  std::vector<Object> result(std::size(protos));
+  std::transform(std::begin(protos), std::end(protos), std::begin(result),
                  object_from_proto);
   return result;
 }
@@ -43,8 +43,8 @@ void ToRepeatedPtrField(
     const std::vector<Object>& objects,
     google::protobuf::RepeatedPtrField<Proto>* repeated_field,
     Convertor proto_from_object) {
-  repeated_field->Reserve(objects.size());
-  std::transform(objects.begin(), objects.end(),
+  repeated_field->Reserve(std::size(objects));
+  std::transform(std::begin(objects), std::end(objects),
                  google::protobuf::RepeatedFieldBackInserter(repeated_field),
                  proto_from_object);
 }

--- a/gematria/basic_block/basic_block_protos.h
+++ b/gematria/basic_block/basic_block_protos.h
@@ -41,6 +41,12 @@ InstructionOperand InstructionOperandFromProto(
 CanonicalizedOperandProto ProtoFromInstructionOperand(
     const InstructionOperand& operand);
 
+// Creates an annotation data structure from a proto.
+Annotation AnnotationFromProto(const AnnotationProto& proto);
+
+// Creates a proto representing the given annotation.
+AnnotationProto ProtoFromAnnotation(const Annotation& annotation);
+
 // Creates an instruction data structure from a proto.
 Instruction InstructionFromProto(const CanonicalizedInstructionProto& proto);
 

--- a/gematria/basic_block/basic_block_protos_test.cc
+++ b/gematria/basic_block/basic_block_protos_test.cc
@@ -144,6 +144,26 @@ TEST(ProtoFromInstructionOperandTest, Memory) {
       EqualsProto(R"pb(memory { alias_group_id: 123 })pb"));
 }
 
+TEST(AnnotationFromProtoTest, AllFields) {
+  const AnnotationProto proto = ParseTextProto(R"pb(
+    name: 'cache_miss_freq'
+    value: 0.875
+  )pb");
+  Annotation annotation = AnnotationFromProto(proto);
+  EXPECT_EQ(annotation.name, "cache_miss_freq");
+  EXPECT_EQ(annotation.value, 0.875);
+}
+
+TEST(ProtoFromAnnotationTest, AllFields) {
+  const Annotation annotation(
+      /* name = */ "cache_miss_freq",
+      /* value = */ 0.875);
+  EXPECT_THAT(ProtoFromAnnotation(annotation), EqualsProto(R"pb(
+                name: 'cache_miss_freq'
+                value: 0.875
+              )pb"));
+}
+
 TEST(InstructionFromProtoTest, AllFields) {
   const CanonicalizedInstructionProto proto = ParseTextProto(R"pb(
     mnemonic: "ADC"
@@ -156,6 +176,7 @@ TEST(InstructionFromProtoTest, AllFields) {
     implicit_output_operands { register_name: "EFLAGS" }
     implicit_input_operands { register_name: "EFLAGS" }
     implicit_input_operands { immediate_value: 1 }
+    instruction_annotations { name: "cache_miss_freq" value: 0.875 }
   )pb");
   Instruction instruction = InstructionFromProto(proto);
   EXPECT_EQ(
@@ -169,7 +190,9 @@ TEST(InstructionFromProtoTest, AllFields) {
                    InstructionOperand::ImmediateValue(1)},
                   /* output_operands = */ {InstructionOperand::Register("RAX")},
                   /* implicit_output_operands = */
-                  {InstructionOperand::Register("EFLAGS")}));
+                  {InstructionOperand::Register("EFLAGS")},
+                  /* instruction_annotations = */
+                  {Annotation("cache_miss_freq", 0.875)}));
 }
 
 TEST(ProtoFromInstructionTest, AllFields) {
@@ -205,6 +228,7 @@ TEST(BasicBlockFromProtoTest, SomeInstructions) {
       llvm_mnemonic: "MOV64rr"
       output_operands: { register_name: "RCX" }
       input_operands: { register_name: "RAX" }
+      instruction_annotations: { name: "cache_miss_freq" value: 0.875 }
     }
     canonicalized_instructions: {
       mnemonic: "NOT"
@@ -223,7 +247,9 @@ TEST(BasicBlockFromProtoTest, SomeInstructions) {
                /* input_operands = */ {InstructionOperand::Register("RAX")},
                /* implicit_input_operands = */ {},
                /* output_operands = */ {InstructionOperand::Register("RCX")},
-               /* implicit_output_operands = */ {}),
+               /* implicit_output_operands = */ {},
+               /* instruction_annotations = */
+               {Annotation("cache_miss_freq", 0.875)}),
            Instruction(
                /* mnemonic = */ "NOT",
                /* llvm_mnemonic = */ "NOT64r",
@@ -231,7 +257,8 @@ TEST(BasicBlockFromProtoTest, SomeInstructions) {
                /* input_operands = */ {InstructionOperand::Register("RCX")},
                /* implicit_input_operands = */ {},
                /* output_operands = */ {InstructionOperand::Register("RCX")},
-               /* implicit_output_operands = */ {})}));
+               /* implicit_output_operands = */ {},
+               /* instruction_annotations = */ {})}));
 }
 
 }  // namespace

--- a/gematria/basic_block/basic_block_test.cc
+++ b/gematria/basic_block/basic_block_test.cc
@@ -318,6 +318,28 @@ TEST(InstructionOperandTest, AsTokenList) {
   }
 }
 
+// TODO(virajbshah): Add tests for Annotation.
+TEST(AnnotationTest, Constructor) {
+  constexpr char kName[] = "cache_miss_freq";
+  constexpr double kValue = 0.875;
+
+  const Annotation annotation(
+      /* name = */ kName,
+      /* value = */ kValue);
+  EXPECT_EQ(annotation.name, kName);
+  EXPECT_EQ(annotation.value, kValue);
+}
+
+TEST(AnnotationTest, ToString) {
+  const Annotation annotation(
+      /* name = */ "cache_miss_freq",
+      /* value = */ 0.875);
+
+  constexpr char kExpectedString[] =
+      "Annotation(name='cache_miss_freq', value=0.875)";
+  EXPECT_EQ(annotation.ToString(), kExpectedString);
+}
+
 TEST(InstructionTest, Constructor) {
   constexpr char kMnemonic[] = "MOV";
   constexpr char kLlvmMnemonic[] = "MOV32rr";
@@ -330,6 +352,8 @@ TEST(InstructionTest, Constructor) {
       InstructionOperand::MemoryLocation(3)};
   const std::vector<InstructionOperand> kImplicitOutputOperands = {
       InstructionOperand::Register("EFLAGS")};
+  const std::vector<Annotation> kInstructionAnnotations = {
+      Annotation("cache_miss_freq", 0.875)};
 
   const Instruction instruction(
       /* mnemonic = */ kMnemonic,
@@ -338,7 +362,8 @@ TEST(InstructionTest, Constructor) {
       /* input_operands = */ kInputOperands,
       /* implicit_input_operands = */ kImplicitInputOperands,
       /* output_operands = */ kOutputOperands,
-      /* implicit_output_operands = */ kImplicitOutputOperands);
+      /* implicit_output_operands = */ kImplicitOutputOperands,
+      /* instruction_annotations = */ kInstructionAnnotations);
   EXPECT_EQ(instruction.mnemonic, kMnemonic);
   EXPECT_EQ(instruction.llvm_mnemonic, kLlvmMnemonic);
   EXPECT_EQ(instruction.prefixes, kPrefixes);
@@ -346,6 +371,7 @@ TEST(InstructionTest, Constructor) {
   EXPECT_EQ(instruction.implicit_input_operands, kImplicitInputOperands);
   EXPECT_EQ(instruction.output_operands, kOutputOperands);
   EXPECT_EQ(instruction.implicit_output_operands, kImplicitOutputOperands);
+  EXPECT_EQ(instruction.instruction_annotations, kInstructionAnnotations);
 }
 
 TEST(InstructionTest, AsTokenList) {
@@ -360,6 +386,8 @@ TEST(InstructionTest, AsTokenList) {
       InstructionOperand::MemoryLocation(3)};
   const std::vector<InstructionOperand> kImplicitOutputOperands = {
       InstructionOperand::Register("EFLAGS")};
+  const std::vector<Annotation> kInstructionAnnotations = {
+      Annotation("cache_miss_freq", 0.875)};
 
   const Instruction instruction(
       /* mnemonic = */ kMnemonic,
@@ -368,7 +396,8 @@ TEST(InstructionTest, AsTokenList) {
       /* input_operands = */ kInputOperands,
       /* implicit_input_operands = */ kImplicitInputOperands,
       /* output_operands = */ kOutputOperands,
-      /* implicit_output_operands = */ kImplicitOutputOperands);
+      /* implicit_output_operands = */ kImplicitOutputOperands,
+      /* instruction_annotations = */ kInstructionAnnotations);
 
   EXPECT_THAT(instruction.AsTokenList(),
               ElementsAre(kPrefixes[0], kPrefixes[1], kMnemonic,
@@ -387,7 +416,9 @@ TEST(InstructionTest, ToString) {
       /* implicit_input_operands = */ {InstructionOperand::Register("EFLAGS")},
       /* output_operands = */ {InstructionOperand::Register("RAX")},
       /* implicit_output_operands = */
-      {InstructionOperand::Register("EFLAGS")});
+      {InstructionOperand::Register("EFLAGS")},
+      /* instruction_annotations = */
+      {Annotation("MEM_LOAD_RETIRED:L3_MISS", 0.875)});
   constexpr char kExpectedString[] =
       "Instruction(mnemonic='ADC', llvm_mnemonic='ADC32rr', "
       "prefixes=('LOCK',), "
@@ -395,7 +426,9 @@ TEST(InstructionTest, ToString) {
       "InstructionOperand.from_register('RBX'),), "
       "implicit_input_operands=(InstructionOperand.from_register('EFLAGS'),), "
       "output_operands=(InstructionOperand.from_register('RAX'),), "
-      "implicit_output_operands=(InstructionOperand.from_register('EFLAGS'),))";
+      "implicit_output_operands=(InstructionOperand.from_register('EFLAGS'),), "
+      "instruction_annotations=(Annotation(name='MEM_LOAD_RETIRED:L3_MISS', "
+      "value=0.875),))";
   EXPECT_EQ(instruction.ToString(), kExpectedString);
 }
 
@@ -492,7 +525,10 @@ TEST(BasicBlockTest, Constructor) {
       /* implicit_input_operands = */ {InstructionOperand::Register("EFLAGS")},
       /* output_operands = */ {InstructionOperand::Register("RAX")},
       /* implicit_output_operands = */
-      {InstructionOperand::Register("EFLAGS")});
+      {InstructionOperand::Register("EFLAGS")},
+      /* instruction_annotations = */
+      {Annotation("MEM_LOAD_RETIRED:L3_MISS", 0.875)});
+
   const BasicBlock block({instruction});
   EXPECT_THAT(block.instructions, ElementsAre(instruction));
 }
@@ -515,7 +551,10 @@ TEST(BasicBlockTest, Equality) {
       /* implicit_input_operands = */ {InstructionOperand::Register("EFLAGS")},
       /* output_operands = */ {InstructionOperand::Register("RAX")},
       /* implicit_output_operands = */
-      {InstructionOperand::Register("EFLAGS")}));
+      {InstructionOperand::Register("EFLAGS")},
+      /* instruction_annotations = */
+      {Annotation("MEM_LOAD_RETIRED:L3_MISS", 0.875)}));
+
   EXPECT_NE(block_1, block_2);
   EXPECT_FALSE(block_1 == block_2);
 
@@ -530,7 +569,10 @@ TEST(BasicBlockTest, Equality) {
       /* implicit_input_operands = */ {InstructionOperand::Register("EFLAGS")},
       /* output_operands = */ {InstructionOperand::Register("RAX")},
       /* implicit_output_operands = */
-      {InstructionOperand::Register("EFLAGS")}));
+      {InstructionOperand::Register("EFLAGS")},
+      /* instruction_annotations = */
+      {Annotation("MEM_LOAD_RETIRED:L3_MISS", 0.875)}));
+
   EXPECT_EQ(block_1, block_2);
   EXPECT_FALSE(block_1 != block_2);
 
@@ -551,7 +593,10 @@ TEST(BasicBlockTest, ToString) {
       /* implicit_input_operands = */ {InstructionOperand::Register("EFLAGS")},
       /* output_operands = */ {InstructionOperand::Register("RAX")},
       /* implicit_output_operands = */
-      {InstructionOperand::Register("EFLAGS")});
+      {InstructionOperand::Register("EFLAGS")},
+      /* instruction_annotations = */
+      {Annotation("MEM_LOAD_RETIRED:L3_MISS", 0.875)});
+
   BasicBlock block({instruction});
   constexpr char kExpectedString[] =
       "BasicBlock(instructions=InstructionList((Instruction(mnemonic='ADC', "
@@ -560,7 +605,9 @@ TEST(BasicBlockTest, ToString) {
       "InstructionOperand.from_register('RBX'),), "
       "implicit_input_operands=(InstructionOperand.from_register('EFLAGS'),), "
       "output_operands=(InstructionOperand.from_register('RAX'),), "
-      "implicit_output_operands=(InstructionOperand.from_register('EFLAGS'),)),"
+      "implicit_output_operands=(InstructionOperand.from_register('EFLAGS'),), "
+      "instruction_annotations=(Annotation(name='MEM_LOAD_RETIRED:L3_MISS', "
+      "value=0.875),)),"
       ")))";
   EXPECT_EQ(block.ToString(), kExpectedString);
 }

--- a/gematria/basic_block/python/BUILD.bazel
+++ b/gematria/basic_block/python/BUILD.bazel
@@ -46,6 +46,7 @@ gematria_py_test(
     deps = [
         ":basic_block",
         ":basic_block_protos",
+        "//gematria/proto:annotation_py_pb2",
         "//gematria/proto:basic_block_py_pb2",
         "//gematria/proto:canonicalized_instruction_py_pb2",
     ],

--- a/gematria/basic_block/python/basic_block.cc
+++ b/gematria/basic_block/python/basic_block.cc
@@ -189,7 +189,8 @@ PYBIND11_MODULE(basic_block, m) {
   py::class_<Annotation> annotation(m, "Annotation");
   annotation
       .def(py::init<std::string /* name */, double /* value */>(),
-           py::arg("name") = std::string(), py::arg("value"))
+           // `value` defaults to -1 to match the bound C++ constructor.
+           py::arg("name") = std::string(), py::arg("value") = -1)
       .def("__repr__", &Annotation::ToString)
       .def("__eq__", &Annotation::operator==)
       .def("__copy__",

--- a/gematria/basic_block/python/basic_block.cc
+++ b/gematria/basic_block/python/basic_block.cc
@@ -30,6 +30,7 @@
 
 PYBIND11_MAKE_OPAQUE(std::vector<std::string>);
 PYBIND11_MAKE_OPAQUE(std::vector<gematria::InstructionOperand>);
+PYBIND11_MAKE_OPAQUE(std::vector<gematria::Annotation>);
 PYBIND11_MAKE_OPAQUE(std::vector<gematria::Instruction>);
 
 namespace gematria {
@@ -185,24 +186,44 @@ PYBIND11_MODULE(basic_block, m) {
 
   py::bind_vector<std::vector<InstructionOperand>>(m, "InstructionOperandList");
 
-  py::class_<Instruction>(m, "Instruction")
+  py::class_<Annotation> annotation(m, "Annotation");
+  annotation
+      .def(py::init<std::string /* name */, double /* value */>(),
+           py::arg("name") = std::string(), py::arg("value"))
+      .def("__repr__", &Annotation::ToString)
+      .def("__eq__", &Annotation::operator==)
+      .def("__copy__",
+           [](const Annotation& annotation) { return Annotation(annotation); })
       .def(
-          py::init<
-              std::string /* mnemonic */, std::string /* llvm_mnemonic */,
-              std::vector<std::string> /* prefixes */,
-              std::vector<InstructionOperand> /* input_operands */,
-              std::vector<InstructionOperand> /* implicit_input_operands */,
-              std::vector<InstructionOperand> /* output_oeprands */,
-              std::vector<InstructionOperand> /* implicit_output_operands */>(),
-          py::arg("mnemonic") = std::string(),
-          py::arg("llvm_mnemonic") = std::string(),
-          py::arg("prefixes") = std::vector<std::string>(),
-          py::arg("input_operands") = std::vector<InstructionOperand>(),
-          py::arg("implicit_input_operands") =
-              std::vector<InstructionOperand>(),
-          py::arg("output_operands") = std::vector<InstructionOperand>(),
-          py::arg("implicit_output_operands") =
-              std::vector<InstructionOperand>())
+          "__deepcopy__",
+          [](const Annotation& annotation, py::dict) {
+            return Annotation(annotation);
+          },
+          py::arg("memo"))
+      .def_readonly("name", &Annotation::name)
+      .def_readonly("value", &Annotation::value);
+
+  py::bind_vector<std::vector<Annotation>>(m, "AnnotationList");
+
+  py::class_<Instruction>(m, "Instruction")
+      .def(py::init<
+               std::string /* mnemonic */, std::string /* llvm_mnemonic */,
+               std::vector<std::string> /* prefixes */,
+               std::vector<InstructionOperand> /* input_operands */,
+               std::vector<InstructionOperand> /* implicit_input_operands */,
+               std::vector<InstructionOperand> /* output_operands */,
+               std::vector<InstructionOperand> /* implicit_output_operands */,
+               std::vector<Annotation> /* instruction_annotations */>(),
+           py::arg("mnemonic") = std::string(),
+           py::arg("llvm_mnemonic") = std::string(),
+           py::arg("prefixes") = std::vector<std::string>(),
+           py::arg("input_operands") = std::vector<InstructionOperand>(),
+           py::arg("implicit_input_operands") =
+               std::vector<InstructionOperand>(),
+           py::arg("output_operands") = std::vector<InstructionOperand>(),
+           py::arg("implicit_output_operands") =
+               std::vector<InstructionOperand>(),
+           py::arg("instruction_annotations") = std::vector<Annotation>())
       .def("__str__", &Instruction::ToString)
       .def("__repr__", &Instruction::ToString)
       .def("__eq__", &Instruction::operator==)
@@ -225,7 +246,9 @@ PYBIND11_MODULE(basic_block, m) {
                      &Instruction::implicit_input_operands)
       .def_readwrite("output_operands", &Instruction::output_operands)
       .def_readwrite("implicit_output_operands",
-                     &Instruction::implicit_output_operands);
+                     &Instruction::implicit_output_operands)
+      .def_readwrite("instruction_annotations",
+                     &Instruction::instruction_annotations);
 
   py::bind_vector<std::vector<Instruction>>(m, "InstructionList");
 

--- a/gematria/basic_block/python/basic_block_protos.cc
+++ b/gematria/basic_block/python/basic_block_protos.cc
@@ -34,6 +34,7 @@ PYBIND11_MODULE(basic_block_protos, m) {
   m.def("instruction_operand_from_proto", InstructionOperandFromProto,
         py::arg("proto"));
   m.def("address_tuple_from_proto", AddressTupleFromProto, py::arg("proto"));
+  m.def("annotation_from_proto", AnnotationFromProto, py::arg("proto"));
 }
 
 }  // namespace gematria

--- a/gematria/basic_block/python/basic_block_test.py
+++ b/gematria/basic_block/python/basic_block_test.py
@@ -201,6 +201,9 @@ class InstructionTest(absltest.TestCase):
         implicit_output_operands=basic_block.InstructionOperandList((
             basic_block.InstructionOperand.from_register('EFLAGS'),
         )),
+        instruction_annotations=basic_block.AnnotationList((
+            basic_block.Annotation('cache_miss_freq', 0.875),
+        )),
     )
     self.assertEqual(instruction.mnemonic, 'ADC')
     self.assertEqual(instruction.llvm_mnemonic, 'ADC32rr')
@@ -223,6 +226,10 @@ class InstructionTest(absltest.TestCase):
     self.assertSequenceEqual(
         instruction.implicit_output_operands,
         (basic_block.InstructionOperand.from_register('EFLAGS'),),
+    )
+    self.assertSequenceEqual(
+        instruction.instruction_annotations,
+        (basic_block.Annotation('cache_miss_freq', 0.875),),
     )
 
     instruction = basic_block.Instruction(

--- a/gematria/proto/BUILD.bazel
+++ b/gematria/proto/BUILD.bazel
@@ -15,6 +15,9 @@ gematria_proto_library(
 gematria_proto_library(
     name = "canonicalized_instruction_proto",
     srcs = ["canonicalized_instruction.proto"],
+    deps = [
+        ":annotation_proto",
+    ],
 )
 
 gematria_proto_library(
@@ -23,4 +26,9 @@ gematria_proto_library(
     deps = [
         ":basic_block_proto",
     ],
+)
+
+gematria_proto_library(
+    name = "annotation_proto",
+    srcs = ["annotation.proto"],
 )

--- a/gematria/proto/annotation.proto
+++ b/gematria/proto/annotation.proto
@@ -1,0 +1,27 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package gematria;
+
+// Contains annotations to supply additional information to the model, such as
+// cache-miss frequencies, or branching related statistics.
+message AnnotationProto {
+  // A name or label for the annotation.
+  string name = 1;
+  // The annotation value, holding information such as measurements or
+  // statistics like event frequency or rate.
+  double value = 2;
+}

--- a/gematria/proto/annotation.proto
+++ b/gematria/proto/annotation.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Google Inc.
+// Copyright 2024 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gematria/proto/canonicalized_instruction.proto
+++ b/gematria/proto/canonicalized_instruction.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package gematria;
 
+import "gematria/proto/annotation.proto";
+
 // Contains information about an instruction and all its inputs and outputs.
 // This proto can be used to create the embedding of the instruction as
 // described in the Ithemal [1] and Granite [2] papers.
@@ -51,6 +53,9 @@ message CanonicalizedInstructionProto {
 
   // The list of implicit input operands of the instruction.
   repeated CanonicalizedOperandProto implicit_input_operands = 7;
+
+  // Runtime related instruction level annotations.
+  repeated AnnotationProto instruction_annotations = 8;
 }
 
 // Contains information about a single operand in the canonicalized instruction.


### PR DESCRIPTION
Adds instruction annotations to the proto specification (`AnnotationProto`) , the graph builder basic block representation (`Annotation`), and functions to convert between the two (`AnnotationFromProto` and `ProtoFromAnnotation`).
