### PR TITLE
Switch to using fast cpp protos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,4 +7,5 @@ build \
   --strict_proto_deps=off \
   --cxxopt=-std=c++17 \
   --host_cxxopt=-std=c++17 \
-  --repo_env=CC=clang
+  --repo_env=CC=clang \
+  --define=use_fast_cpp_protos=true


### PR DESCRIPTION
This patch sets --define=use_fast_cpp_protos=true to ensure that we are using the cpp protos instead of the python protos. This results in about an 85% reduction in time spent loading protos due to the lack of needing to serialize/deserialize at the language interface.