### PR TITLE
Add sanitizer configs to bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,4 +8,18 @@ build \
   --cxxopt=-std=c++17 \
   --host_cxxopt=-std=c++17 \
   --repo_env=CC=clang \
-  --define=use_fast_cpp_protos=true
+  --define=use_fast_cpp_protos=true \
+  --linkopt="-fuse-ld=lld"
+
+build:asan --strip=never
+build:asan --copt=-fsanitize=address
+build:asan --copt=-O0
+build:asan --copt=-fno-omit-frame-pointer
+build:asan --copt=-DADDRESS_SANITIZER
+build:asan --linkopt=-fsanitize=address
+
+build:tsan --strip=never
+build:tsan --copt=-fsanitize=thread
+build:tsan --copt=-fno-omit-frame-pointer
+build:tsan --copt=-DTHREAD_SANITIZER
+build:tsan --linkopt=-fsanitize=thread


### PR DESCRIPTION
This patch adds sanitizer configs to .bazelrc so a developer can simply use --config=asan or --config=tsan on a specific test to see if there are any issues. It seems like asan might be catching some issues I will have to look into this in a bit.