### PR TITLE
Bump clang format version in CI to v18

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Check c++ formatting
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '16'
+        clang-format-version: '18'
         check-path: 'src'
   check-bazel-formatting:
     name: Bazel Formatting Check

--- a/llvm_cm/tools/llvm-cm/llvm-cm.cpp
+++ b/llvm_cm/tools/llvm-cm/llvm-cm.cpp
@@ -393,8 +393,7 @@ double CostModel::getLatency(
         EnteredBb = true;
         ThisBb = Label;
 
-        LLVM_DEBUG(dbgs() << "<"
-                          << "BB" + Twine(Label) << ">: "
+        LLVM_DEBUG(dbgs() << "<" << "BB" + Twine(Label) << ">: "
                           << format("%016" PRIx64 " ", CurrAddr) << "\n");
       }
     }


### PR DESCRIPTION
This patch bumps the clang format version in CI to v18 as v18 is the latest LLVM release (currently) and includes quite a few patches for clang-format.