### PR TITLE
Make llvm-cm tests invariant against small FP differences

### DIFF
--- a/llvm_cm/test/X86/bb-frequency.s
+++ b/llvm_cm/test/X86/bb-frequency.s
@@ -13,10 +13,10 @@ main,3,3.809524e-01
 
 //--- bb-frequency-test.s
 # CHECK:      <main>:
-# CHECK-NEXT: Calculated Frequency: 1.803670e+02
+# CHECK-NEXT: Calculated Frequency: 1.8{{[0-9]+}}e+02
 
 # CHECK-COUNT: <main>:
-# CHECK-COUNT: Calculated Frequency: 6.000000e+00
+# CHECK-COUNT: Calculated Frequency: 6.0{{[0-9]+}}e+00
 
  .text
  .file "bb-frequency.ll"

--- a/llvm_cm/test/X86/multi_func.s
+++ b/llvm_cm/test/X86/multi_func.s
@@ -5,31 +5,31 @@
 
 
 # CHECK:      <reverse>:
-# CHECK-NEXT: Calculated Frequency: 8.342712e+03
+# CHECK-NEXT: Calculated Frequency: 8.3{{[0-9]+}}e+03
 # CHECK-NEXT: <tallestBillboard>:
-# CHECK-NEXT: Calculated Frequency: 2.928509e+05
+# CHECK-NEXT: Calculated Frequency: 2.9{{[0-9]+}}e+05
 # CHECK-NEXT: <isMatch>:
-# CHECK-NEXT: Calculated Frequency: 8.204262e+02
+# CHECK-NEXT: Calculated Frequency: 8.2{{[0-9]+}}e+02
 # CHECK-NEXT: <bubbleSort>:
-# CHECK-NEXT: Calculated Frequency: 6.651033e+04
+# CHECK-NEXT: Calculated Frequency: 6.6{{[0-9]+}}e+04
 # CHECK-NEXT: <isPrime>:
-# CHECK-NEXT: Calculated Frequency: 5.754429e+02
+# CHECK-NEXT: Calculated Frequency: 5.7{{[0-9]+}}e+02
 # CHECK-NEXT: <main>:
-# CHECK-NEXT: Calculated Frequency: 8.872796e+03
+# CHECK-NEXT: Calculated Frequency: 8.8{{[0-9]+}}e+03
 
 
 # CHECK-COUNT: <reverse>:
-# CHECK-COUNT: Calculated Frequency: 1.468750e+02
+# CHECK-COUNT: Calculated Frequency: 1.4{{[0-9]+}}e+02
 # CHECK-COUNT: <tallestBillboard>:
-# CHECK-COUNT: Calculated Frequency: 4.478530e+03
+# CHECK-COUNT: Calculated Frequency: 4.4{{[0-9]+}}e+03
 # CHECK-COUNT: <isMatch>:
-# CHECK-COUNT: Calculated Frequency: 2.274074e+01
+# CHECK-COUNT: Calculated Frequency: 2.2{{[0-9]+}}e+01
 # CHECK-COUNT: <bubbleSort>:
-# CHECK-COUNT: Calculated Frequency: 2.007125e+03
+# CHECK-COUNT: Calculated Frequency: 2.0{{[0-9]+}}e+03
 # CHECK-COUNT: <isPrime>:
-# CHECK-COUNT: Calculated Frequency: 2.778125e+01
+# CHECK-COUNT: Calculated Frequency: 2.7{{[0-9]+}}e+01
 # CHECK-COUNT: <main>:
-# CHECK-COUNT: Calculated Frequency: 2.346250e+02
+# CHECK-COUNT: Calculated Frequency: 2.3{{[0-9]+}}e+02
 
  .text
  .file "test.c"

--- a/llvm_cm/test/X86/profile-dump.s
+++ b/llvm_cm/test/X86/profile-dump.s
@@ -12,14 +12,14 @@ f1,2,1.000000e+00
 
 //--- profile-dump-test.s
 # CHECK:      <f2>:
-# CHECK-NEXT: Calculated Frequency: 9.630392e+01
+# CHECK-NEXT: Calculated Frequency: 9.6{{[0-9]+}}e+01
 # CHECK-NEXT: <f1>:
-# CHECK-NEXT: Calculated Frequency: 1.629852e+02
+# CHECK-NEXT: Calculated Frequency: 1.6{{[0-9]+}}e+02
 
 # CHECK-COUNT: <f2>:
-# CHECK-COUNT: Calculated Frequency: 3.000000e+00
+# CHECK-COUNT: Calculated Frequency: 3.0{{[0-9]+}}e+00
 # CHECK-COUNT: <f1>:
-# CHECK-COUNT: Calculated Frequency: 8.500000e+00
+# CHECK-COUNT: Calculated Frequency: 8.5{{[0-9]+}}e+00
 
 
  .text


### PR DESCRIPTION
Currently the llvm-cm tests are quite sensitive to small FP differences as they evaluate a model where the results are not guaranteed to be exact across hardware. Check the two most significant figures and then regex that we have numbers to make them invariant against slight changes.