### PR TITLE
Use information from AccessedAddrs in conversion tool

### DIFF
--- a/gematria/datasets/BUILD.bazel
+++ b/gematria/datasets/BUILD.bazel
@@ -149,12 +149,12 @@ cc_library(
     srcs = ["find_accessed_addrs_exegesis.cc"],
     hdrs = ["find_accessed_addrs_exegesis.h"],
     deps = [
+        ":basic_block_utils",
         ":find_accessed_addrs",
         "//gematria/llvm:disassembler",
         "//gematria/llvm:llvm_architecture_support",
         "@llvm-project//llvm:Exegesis",
         "@llvm-project//llvm:Support",
-        ":basic_block_utils",
     ],
 )
 

--- a/gematria/datasets/BUILD.bazel
+++ b/gematria/datasets/BUILD.bazel
@@ -154,6 +154,7 @@ cc_library(
         "//gematria/llvm:llvm_architecture_support",
         "@llvm-project//llvm:Exegesis",
         "@llvm-project//llvm:Support",
+        ":basic_block_utils",
     ],
 )
 

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -39,7 +39,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 
-constexpr unsigned kInitialMemValBitWidth = 64;
 constexpr std::string_view kRegDefPrefix = "# LLVM-EXEGESIS-DEFREG ";
 constexpr std::string_view kMemDefPrefix = "# LLVM-EXEGESIS-MEM-DEF ";
 constexpr std::string_view kMemMapPrefix = "# LLVM-EXEGESIS-MEM-MAP ";
@@ -212,16 +211,10 @@ absl::Status WriteAsmOutput(const AnnotatedBlock& annotated_block,
 
   // Multiple mappings can point to the same definition.
   if (annotated_block.accessed_addrs.accessed_blocks.size() > 0) {
-    std::string memory_value_string = gematria::ConvertHexToString(
-        annotated_block.accessed_addrs.block_contents);
-    // Prefix the string with zeroes as llvm-exegesis assumes the bit width
-    // of the memory value based on the number of characters in the string.
-    if (kInitialMemValBitWidth > memory_value_string.size() * 4)
-      memory_value_string =
-          std::string(
-              (kInitialMemValBitWidth - memory_value_string.size() * 4) / 4,
-              '0') +
-          memory_value_string;
+    // Make sure to left-pad the memory value string so llvm-exegesis is able to
+    // assume the right bit-width.
+    std::string memory_value_string =
+        absl::StrFormat("%016x", annotated_block.accessed_addrs.block_contents);
     output_file << kMemDefPrefix << kMemNamePrefix << " "
                 << annotated_block.accessed_addrs.block_size << " "
                 << memory_value_string << "\n";

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/blocks_per_json_file.test
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/blocks_per_json_file.test
@@ -3,6 +3,8 @@
 ; RUN: split-file %s %t
 ; RUN: mkdir %t.jsondir
 ; RUN: %convert_bhive_to_llvm_exegesis_input --json_output_dir=%t.jsondir --bhive_csv=%t/test.csv --blocks_per_json_file=1
+; RUN: cat %t.jsondir/0.json > /tmp/0.json
+; RUN: cat %t.jsondir/1.json > /tmp/1.json
 ; RUN: cat %t.jsondir/0.json | FileCheck --check-prefix FILE1 %s
 ; RUN: cat %t.jsondir/1.json | FileCheck --check-prefix FILE2 %s
 
@@ -16,7 +18,7 @@
 ; FILE1:       {
 ; FILE1:         "Name": "MEM",
 ; FILE1:         "Size": 4096,
-; FILE1:         "Value": 305419776
+; FILE1:         "Value": 34359738376
 ; FILE1:       }
 ; FILE1:     ],
 ; FILE1:     "MemoryMappings": [
@@ -35,7 +37,7 @@
 ; FILE2:       {
 ; FILE2:         "Name": "MEM",
 ; FILE2:         "Size": 4096,
-; FILE2:         "Value": 305419776
+; FILE2:         "Value": 34359738376
 ; FILE2:       }
 ; FILE2:     ],
 ; FILE2:     "MemoryMappings": [

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/conversion.test
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/conversion.test
@@ -4,11 +4,12 @@
 ; RUN: split-file %s %t
 ; RUN: mkdir %t.asmdir
 ; RUN: %convert_bhive_to_llvm_exegesis_input --asm_output_dir=%t.asmdir --bhive_csv=%t/test.csv
+; RUN: cat %t.asmdir/0.test > /tmp/0.test
 ; RUN: cat %t.asmdir/0.test | FileCheck %s
 
-; CHECK: # LLVM-EXEGESIS-DEFREG RCX 12345600
-; CHECK: # LLVM-EXEGESIS-DEFREG RSI 12345600
-; CHECK: # LLVM-EXEGESIS-MEM-DEF MEM 4096 0000000012345600
+; CHECK: # LLVM-EXEGESIS-DEFREG RCX 15000
+; CHECK: # LLVM-EXEGESIS-DEFREG RSI 15000
+; CHECK: # LLVM-EXEGESIS-MEM-DEF MEM 4096 0000000800000008
 ; CHECK: # LLVM-EXEGESIS-MEM-MAP MEM 86016
 ; CHECK:	cmpl	(%rcx), %esi
 

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/json.test
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/json.test
@@ -13,7 +13,7 @@
 ; CHECK:       {
 ; CHECK:         "Name": "MEM",
 ; CHECK:         "Size": 4096,
-; CHECK:         "Value": 305419776
+; CHECK:         "Value": 34359738376
 ; CHECK:       }
 ; CHECK:     ],
 ; CHECK:     "MemoryMappings": [
@@ -25,11 +25,11 @@
 ; CHECK:     "RegisterDefinitions": [
 ; CHECK:       {
 ; CHECK:         "Register": 54,
-; CHECK:         "Value": 305419776
+; CHECK:         "Value": 86016
 ; CHECK:       },
 ; CHECK:       {
 ; CHECK:         "Register": 60,
-; CHECK:         "Value": 305419776
+; CHECK:         "Value": 86016
 ; CHECK:       }
 ; CHECK:     ]
 ; CHECK:   }

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -191,13 +191,12 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     MemAnnotations.accessed_blocks.push_back(Mapping.Address);
   }
 
-  std::vector<unsigned> UsedRegisters = gematria::getUsedRegisters(*DisInstructions, State.getRegInfo(), State.getInstrInfo());
+  std::vector<unsigned> UsedRegisters = gematria::getUsedRegisters(
+      *DisInstructions, State.getRegInfo(), State.getInstrInfo());
 
   for (const unsigned UsedRegister : UsedRegisters) {
-    MemAnnotations.initial_regs.push_back({
-      .register_index = UsedRegister,
-      .register_value = kInitialRegVal
-    });
+    MemAnnotations.initial_regs.push_back(
+        {.register_index = UsedRegister, .register_value = kInitialRegVal});
   }
 
   MemAnnotations.block_contents = kInitialMemVal;

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -23,6 +23,7 @@
 #include "X86.h"
 #include "X86InstrInfo.h"
 #include "X86RegisterInfo.h"
+#include "gematria/datasets/basic_block_utils.h"
 #include "gematria/llvm/disassembler.h"
 #include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
 #include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
@@ -31,6 +32,13 @@
 
 using namespace llvm;
 using namespace llvm::exegesis;
+
+// Use the constants from the BHive paper for setting initial register and
+// memory values. These constants are set to a high enough value to avoid
+// underflow and accesses within the first page, but low enough to avoid
+// exceeding the virtual address space ceiling in most cases.
+constexpr uint64_t kInitialRegVal = 0x12345600;
+constexpr uint64_t kInitialMemVal = 0x12345600;
 
 namespace gematria {
 
@@ -100,7 +108,7 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
   BenchCode.Key.Instructions = Instructions;
 
   MemoryValue MemVal;
-  MemVal.Value = APInt(64, 0x12345600);
+  MemVal.Value = APInt(64, kInitialMemVal);
   MemVal.Index = 0;
   MemVal.SizeBytes = 4096;
 
@@ -113,7 +121,7 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
     RegisterValue RegVal;
     RegVal.Register =
         MRI.getRegClass(X86::GR64_NOREX2RegClassID).getRegister(i);
-    RegVal.Value = APInt(64, 0x12345600);
+    RegVal.Value = APInt(64, kInitialRegVal);
     BenchCode.Key.RegisterInitialValues.push_back(RegVal);
   }
 
@@ -121,7 +129,7 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
        ++i) {
     RegisterValue RegVal;
     RegVal.Register = MRI.getRegClass(X86::VR128RegClassID).getRegister(i);
-    RegVal.Value = APInt(128, 0x12345600);
+    RegVal.Value = APInt(128, kInitialRegVal);
     BenchCode.Key.RegisterInitialValues.push_back(RegVal);
   }
 
@@ -182,6 +190,17 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
   for (const MemoryMapping &Mapping : BenchCode.Key.MemoryMappings) {
     MemAnnotations.accessed_blocks.push_back(Mapping.Address);
   }
+
+  std::vector<unsigned> UsedRegisters = gematria::getUsedRegisters(*DisInstructions, State.getRegInfo(), State.getInstrInfo());
+
+  for (const unsigned UsedRegister : UsedRegisters) {
+    MemAnnotations.initial_regs.push_back({
+      .register_index = UsedRegister,
+      .register_value = kInitialRegVal
+    });
+  }
+
+  MemAnnotations.block_contents = kInitialMemVal;
 
   return MemAnnotations;
 }

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -194,6 +194,8 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
   std::vector<unsigned> UsedRegisters = gematria::getUsedRegisters(
       *DisInstructions, State.getRegInfo(), State.getInstrInfo());
 
+  MemAnnotations.initial_regs.reserve(UsedRegisters.size());
+
   for (const unsigned UsedRegister : UsedRegisters) {
     MemAnnotations.initial_regs.push_back(
         {.register_index = UsedRegister, .register_value = kInitialRegVal});


### PR DESCRIPTION
This patch makes convert_bhive_to_llvm_exegesis_inputs use information from AccessedAddrs like the initial register values and the block contents to emit information to the file rather than assuming a default register value/default block content.