### PR TITLE
Fix type error in extract_tokens_file

### DIFF
--- a/gematria/datasets/python/extract_tokens_file.py
+++ b/gematria/datasets/python/extract_tokens_file.py
@@ -51,7 +51,7 @@ def main(argv) -> None:
   del argv  # Unused.
 
   loaded_protos = tfrecord.read_protos(
-      _INPUT_TFRECORD_FILE.value, throughput_pb2.BasicBlockWithThroughputProto
+      [_INPUT_TFRECORD_FILE.value], throughput_pb2.BasicBlockWithThroughputProto
   )
 
   tokens = set()


### PR DESCRIPTION
tfrecord.read_protos expects a list of strings rather than an individual string path. Convert the single file into an array to satisfy the type checker.