### PR TITLE
Fix sort comparator in extract_bbs_from_obj

### DIFF
--- a/gematria/datasets/extract_bbs_from_obj_lib.cc
+++ b/gematria/datasets/extract_bbs_from_obj_lib.cc
@@ -68,8 +68,10 @@ Expected<std::vector<std::string>> getBasicBlockHexValues(
       }
     }
 
+    // Sort the basic blocks by start address as we assume this holds later
+    // on when iterating through all the basic blocks.
     std::sort(BasicBlocks.begin(), BasicBlocks.end(), [](auto &LHS, auto &RHS) {
-      return std::get<0>(LHS) < std::get<1>(RHS);
+      return std::get<0>(LHS) < std::get<0>(RHS);
     });
 
     if (BasicBlocks.size() == 0) {


### PR DESCRIPTION
The comparator function for sorting basic blocks in extract_bbs_from_obj previously compared the start address of the LHS to the size of the RHS rather than comparing the start addresses. This patch fixes this behavior. This makes the code correct (or at least fixes one correctness issue) and fixes a libc++ assertion (when assertions are enabled).