### PR TITLE
Add name-based lookups to the tflite inference API.

### DIFF
--- a/gematria/granite/graph_builder_model_inference.cc
+++ b/gematria/granite/graph_builder_model_inference.cc
@@ -101,9 +101,19 @@ constexpr int kNumPossibleInputTensors = std::size(kPossibleInputTensors);
 // Basic checks to ensure the look-up table is consistent with `InputTensor`.
 // The second assertion must be manually updated with the first `InputTensor`
 // and the third assertion with the last `InputTensor` when a new one is added.
-static_assert(static_cast<int>(kPossibleInputTensors[0].first) == 0,
-              "The start of `kPossibleInputTensors` is not aligned with the "
-              "start of `InputTensor`");
+template <typename Container>
+constexpr bool IsConsistentWithEnum(const Container& entries) {
+  const int num_items = std::size(entries);
+  for (int i = 1; i < num_items; ++i) {
+    if (i != static_cast<int>(kPossibleInputTensors[i].first)) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(IsConsistentWithEnum(kPossibleInputTensors),
+              "The sequence of entries in `kPossibleInputTensors` is not "
+              "consistent with `InputTensor`");
 static_assert(static_cast<int>(InputTensor::kDeltaBlockIndex) == 0,
               "`InputTensor` does not begin enumerating from 0");
 static_assert(
@@ -473,7 +483,7 @@ GraphBuilderModelInference::FromTfLiteModel(
       }
     }
     if (!unexpected_input_indices.empty()) {
-      buffer << "Model is has unexpected extra input tensors. ";
+      buffer << "Model has unexpected extra input tensors. ";
       for (const int idx : unexpected_input_indices) {
         buffer << (*interpreter)->GetInputName(idx) << " at index " << idx
                << ", ";

--- a/gematria/granite/graph_builder_model_inference.h
+++ b/gematria/granite/graph_builder_model_inference.h
@@ -22,6 +22,7 @@
 #include "gematria/granite/graph_builder.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
+#include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/model_builder.h"
 
 namespace gematria {
@@ -87,10 +88,22 @@ class GraphBuilderModelInference {
   // structure of a model based on the BasicBlockGraphBuilder class.
   GraphBuilderModelInference(
       std::unique_ptr<BasicBlockGraphBuilder> graph_builder,
-      const tflite::FlatBufferModel* tflite_model);
+      const tflite::FlatBufferModel* tflite_model,
+      std::unique_ptr<tflite::Interpreter> interpreter,
+      std::unique_ptr<std::vector<int>> input_tensor_to_idx,
+      bool uses_deltas = true);
 
   std::unique_ptr<BasicBlockGraphBuilder> graph_builder_;
   const tflite::FlatBufferModel& tflite_model_;
+  std::unique_ptr<tflite::Interpreter> interpreter_;
+
+  // The mapping between input tensors and their indices in the tflite
+  // model. Allows lookups of input tensors without knowing their indices at
+  // compile time.
+  std::unique_ptr<std::vector<int>> input_tensor_to_idx_;
+
+  // Encodes the configuration of input tensors present in the tflite model.
+  const bool uses_deltas_;
 };
 
 }  // namespace gematria

--- a/gematria/granite/graph_builder_model_inference.h
+++ b/gematria/granite/graph_builder_model_inference.h
@@ -90,8 +90,7 @@ class GraphBuilderModelInference {
       std::unique_ptr<BasicBlockGraphBuilder> graph_builder,
       const tflite::FlatBufferModel* tflite_model,
       std::unique_ptr<tflite::Interpreter> interpreter,
-      std::unique_ptr<std::vector<int>> input_tensor_to_idx,
-      bool uses_deltas = true);
+      std::vector<int> input_tensor_to_idx, bool uses_deltas);
 
   std::unique_ptr<BasicBlockGraphBuilder> graph_builder_;
   const tflite::FlatBufferModel& tflite_model_;
@@ -100,7 +99,7 @@ class GraphBuilderModelInference {
   // The mapping between input tensors and their indices in the tflite
   // model. Allows lookups of input tensors without knowing their indices at
   // compile time.
-  std::unique_ptr<std::vector<int>> input_tensor_to_idx_;
+  const std::vector<int> input_tensor_to_idx_;
 
   // Encodes the configuration of input tensors present in the tflite model.
   const bool uses_deltas_;


### PR DESCRIPTION
 * Remove the need to know tensor indices at compile time by examining the tensor names used in the tflite models.