### PR TITLE
Fix twine-related UB in convert_bhive_to_llvm_exegesis_input

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -239,13 +239,14 @@ absl::Status WriteAsmOutput(const AnnotatedBlock& annotated_block,
                             unsigned int file_counter,
                             const llvm::MCRegisterInfo& reg_info) {
   // Create output file path.
-  llvm::Twine output_file_path = llvm::Twine(asm_output_dir)
+  std::string output_file_path = llvm::Twine(asm_output_dir)
                                      .concat("/")
                                      .concat(llvm::Twine(file_counter))
-                                     .concat(".test");
+                                     .concat(".test")
+                                     .str();
 
   // Open output file for writing.
-  std::ofstream output_file(output_file_path.str());
+  std::ofstream output_file(output_file_path);
   if (!output_file.is_open()) {
     return absl::InvalidArgumentError(Twine("Failed to open output file: ")
                                           .concat(output_file_path)


### PR DESCRIPTION
According to the twine documentation, twine assignment when using concatenation can lead to undefined behavior. This was leading to test failures for convert_bhive_to_llvm_exegesis_input when running tests with -c opt. This patch fixes this behavior by converting the twine to a string and storing it in a std::string rather than trying to store it as a twine.

Fixes #147.