### PR TITLE
Cleanup minor mistakes missed in other PRs

### DIFF
--- a/gematria/datasets/python/extract_bbs_from_obj_test.py
+++ b/gematria/datasets/python/extract_bbs_from_obj_test.py
@@ -25,7 +25,7 @@ _OBJECT_FILE_PATH = os.path.join(
 
 class ExtractBBsFromObjTests(absltest.TestCase):
 
-  def test_thing(self):
+  def test_simple_extraction(self):
     self.assertTrue(True)
 
     runfiles_dir = os.environ.get('PYTHON_RUNFILES')

--- a/gematria/datasets/python/extract_bbs_from_obj_test.py
+++ b/gematria/datasets/python/extract_bbs_from_obj_test.py
@@ -26,8 +26,6 @@ _OBJECT_FILE_PATH = os.path.join(
 class ExtractBBsFromObjTests(absltest.TestCase):
 
   def test_simple_extraction(self):
-    self.assertTrue(True)
-
     runfiles_dir = os.environ.get('PYTHON_RUNFILES')
     runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
     assert runfiles_env is not None

--- a/gematria/testing/BUILD.bazel
+++ b/gematria/testing/BUILD.bazel
@@ -75,5 +75,3 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-exports_files(["lit_driver.py"])


### PR DESCRIPTION
This patch cleansup some minor mistakes that I left in some previous PRs, particularly not renaming a test away from a default value and leaving an export_files rule in a BUILD file after deleting it.