### PR TITLE
Add an explicit dependency on `lld` to `Dockerfile`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y clang python3 python3-pip git curl
+RUN apt-get update && apt-get install -y clang python3 python3-pip git curl lld
 ARG bazelisk_version=1.19.0
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk_version}/bazelisk-linux-amd64 > /usr/bin/bazelisk && chmod +x /usr/bin/bazelisk && ln -s /usr/bin/bazelisk /usr/bin/bazel
 WORKDIR /gematria


### PR DESCRIPTION
As of 2024-07-23, `bazel build ...` fails unless `lld` is explicitly installed via `apt-get install`.