### PR TITLE
Disable pytype module-attr around glorot_normal

### DIFF
--- a/gematria/granite/python/token_graph_builder_model.py
+++ b/gematria/granite/python/token_graph_builder_model.py
@@ -279,6 +279,10 @@ class TokenGraphBuilderModel(graph_builder_model_base.GraphBuilderModelBase):
   def _create_graph_network_modules(
       self,
   ) -> Sequence[gnn_model_base.GraphNetworkLayer]:
+    # Disable module-attr around uses of tf_keras.initializers.glorot_normal as
+    # some tf_keras installations setup what is available in tf_keras.initializers
+    # using logic in __init__.py that pytype is not able to understand
+    # correctly.
     # pytype: disable=module-attr
     mlp_initializers = {
         'w': tf_keras.initializers.glorot_normal(),

--- a/gematria/granite/python/token_graph_builder_model.py
+++ b/gematria/granite/python/token_graph_builder_model.py
@@ -279,13 +279,15 @@ class TokenGraphBuilderModel(graph_builder_model_base.GraphBuilderModelBase):
   def _create_graph_network_modules(
       self,
   ) -> Sequence[gnn_model_base.GraphNetworkLayer]:
+    # pytype: disable=module-attr
     mlp_initializers = {
-        'w': tf.keras.initializers.glorot_normal(),
-        'b': tf.keras.initializers.glorot_normal(),
+        'w': tf_keras.initializers.glorot_normal(),
+        'b': tf_keras.initializers.glorot_normal(),
     }
     embedding_initializers = {
-        'embeddings': tf.keras.initializers.glorot_normal(),
+        'embeddings': tf_keras.initializers.glorot_normal(),
     }
+    # pytype: enable=module-attr
     return (
         gnn_model_base.GraphNetworkLayer(
             module=graph_nets.modules.GraphIndependent(

--- a/gematria/granite/python/token_graph_builder_model.py
+++ b/gematria/granite/python/token_graph_builder_model.py
@@ -280,11 +280,11 @@ class TokenGraphBuilderModel(graph_builder_model_base.GraphBuilderModelBase):
       self,
   ) -> Sequence[gnn_model_base.GraphNetworkLayer]:
     mlp_initializers = {
-        'w': tf_keras.initializers.glorot_normal(),
-        'b': tf_keras.initializers.glorot_normal(),
+        'w': tf.keras.initializers.glorot_normal(),
+        'b': tf.keras.initializers.glorot_normal(),
     }
     embedding_initializers = {
-        'embeddings': tf_keras.initializers.glorot_normal(),
+        'embeddings': tf.keras.initializers.glorot_normal(),
     }
     return (
         gnn_model_base.GraphNetworkLayer(


### PR DESCRIPTION
Other installations of tensorflow/tf_keras can have complicated `__init__.py`s that pytype isn't able to comprehend correctly. Disable pytype around the one case of this so we can utilize gematria with alternative dependency installations.