### PR TITLE
Fix pytype error in graph_builder_model_base

### DIFF
--- a/gematria/granite/python/graph_builder_model_base.py
+++ b/gematria/granite/python/graph_builder_model_base.py
@@ -183,7 +183,7 @@ class GraphBuilderModelBase(
 
   @property
   def annotation_names_tensor(self) -> tf.Tensor:
-    return self._annotation_names_tensor
+    return self._annotation_name_tensor
 
   # @Override
   @property


### PR DESCRIPTION
There was a typo in the annotation_names_tensor function in graph_builder_model_base. It returned _annotation_names_tensor, which does not exist. It should return _annotation_name_tensor.