### PR TITLE
Add __builtin_unreachable to end of GetInputTensorName

### DIFF
--- a/gematria/granite/graph_builder_model_inference.cc
+++ b/gematria/granite/graph_builder_model_inference.cc
@@ -78,7 +78,6 @@ constexpr std::string_view kGraphNEdgeTensorName = "GnnModelBase.num_edges";
 constexpr std::string_view kGraphNNodeTensorName = "GnnModelBase.num_nodes";
 constexpr std::string_view kInstructionNodeMaskTensorName =
     "GraphBuilderModelBase.instruction_node_mask";
-constexpr std::string_view kUnknownTensorName = "UnknownName";
 
 // Look-up table between `InputTensor` and input tensor names. Used by
 // `GetInputTensorName` and `GetInputTensorFromName` to create an efficient
@@ -129,7 +128,7 @@ constexpr std::string_view GetInputTensorName(const InputTensor tensor) {
       return name;
     }
   }
-  return kUnknownTensorName;
+  __builtin_unreachable();
 }
 
 // Get the input tensor associated with a name. `name` must be one of the

--- a/gematria/granite/graph_builder_model_inference.cc
+++ b/gematria/granite/graph_builder_model_inference.cc
@@ -78,6 +78,7 @@ constexpr std::string_view kGraphNEdgeTensorName = "GnnModelBase.num_edges";
 constexpr std::string_view kGraphNNodeTensorName = "GnnModelBase.num_nodes";
 constexpr std::string_view kInstructionNodeMaskTensorName =
     "GraphBuilderModelBase.instruction_node_mask";
+constexpr std::string_view kUnknownTensorName = "UnknownName";
 
 // Look-up table between `InputTensor` and input tensor names. Used by
 // `GetInputTensorName` and `GetInputTensorFromName` to create an efficient
@@ -128,6 +129,7 @@ constexpr std::string_view GetInputTensorName(const InputTensor tensor) {
       return name;
     }
   }
+  return kUnknownTensorName;
 }
 
 // Get the input tensor associated with a name. `name` must be one of the


### PR DESCRIPTION
Currently GetInputTensorName can potentially return from a non-void function without actually returning anything. Add `__builtin_unreachable` to the end of the function to mark that we expect this case to never happen.