### PR TITLE
Pin LLVM version used by CMake CI.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,9 @@
 
 name: Gematria CI
 
+env:
+  LLVM_COMMIT: 74a5e7784b32aba5670ff427b158d1e6e38012f1
+
 on:
   push:
     branches:
@@ -63,7 +66,11 @@ jobs:
         with:
           apt: cmake ninja-build libpthreadpool-dev
       - name: Get LLVM
-        run: git clone --depth 1 https://github.com/llvm/llvm-project.git /tmp/llvm-project
+        run: |
+          git clone --depth 1 --no-checkout https://github.com/llvm/llvm-project.git /tmp/llvm-project
+          cd /tmp/llvm-project
+          git fetch --depth 1 origin $LLVM_COMMIT
+          git checkout $LLVM_COMMIT
       - name: Set up TFLite
         run: |
           mkdir /tmp/tflite

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,10 @@
 
 name: Gematria CI
 
+# The pinned version of LLVM. Must be manually updated to match the
+# `LLVM_COMMIT` variable defined in `WORKSPACE`.
+# TODO(virajbshah): Find a better way to keep these two in sync without the
+# need to update one manually every time the other is changed.
 env:
   LLVM_COMMIT: 74a5e7784b32aba5670ff427b158d1e6e38012f1
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,6 +165,9 @@ new_git_repository(
 
 # LLVM and its dependencies
 
+# The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
+# `.github/workflows/main.yaml` must be updated to match this everytime it is
+# changed.
 LLVM_COMMIT = "74a5e7784b32aba5670ff427b158d1e6e38012f1"
 
 LLVM_SHA256 = "a0d8932b90d5a423a7fcf2c70afee531c7f897153c2d7913a757cbecb52aec40"


### PR DESCRIPTION
 * The LLVM version used by the CMake CI is now pinned to that specified by `WORKSPACE`.
 * It must be manually bumped alongside the one in `WORKSPACE`.