### PR TITLE
Bump LLVM version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ name: Gematria CI
 # TODO(virajbshah): Find a better way to keep these two in sync without the
 # need to update one manually every time the other is changed.
 env:
-  LLVM_COMMIT: 74a5e7784b32aba5670ff427b158d1e6e38012f1
+  LLVM_COMMIT: 67a55e01e3f13d6ea5be917765a4171cd68cb5ac
 
 on:
   push:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -168,9 +168,9 @@ new_git_repository(
 # The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
 # `.github/workflows/main.yaml` must be updated to match this everytime it is
 # changed.
-LLVM_COMMIT = "74a5e7784b32aba5670ff427b158d1e6e38012f1"
+LLVM_COMMIT = "67a55e01e3f13d6ea5be917765a4171cd68cb5ac"
 
-LLVM_SHA256 = "a0d8932b90d5a423a7fcf2c70afee531c7f897153c2d7913a757cbecb52aec40"
+LLVM_SHA256 = "e19e037f478a152c08c6324914b61262eabbec88bdaacea718e581820890483c"
 
 http_archive(
     name = "llvm-raw",


### PR DESCRIPTION
This patch bumps the LLVM version to
67a55e01e3f13d6ea5be917765a4171cd68cb5ac, primarily to bump past the change that broke the llvm-cm tests that were subsequently fixed against the new version.