### PR TITLE
Refactor process_and_filter_bbs into a library

### DIFF
--- a/gematria/datasets/BUILD.bazel
+++ b/gematria/datasets/BUILD.bazel
@@ -75,9 +75,7 @@ cc_binary(
     name = "process_and_filter_bbs",
     srcs = ["process_and_filter_bbs.cc"],
     deps = [
-        "//gematria/llvm:disassembler",
-        "//gematria/llvm:llvm_architecture_support",
-        "//gematria/utils:string",
+        ":process_and_filter_bbs_lib",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -233,6 +231,18 @@ cc_library(
     visibility = ["//:internal_users"],
     deps = [
         "@llvm-project//llvm:Object",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "process_and_filter_bbs_lib",
+    srcs = ["process_and_filter_bbs_lib.cc"],
+    hdrs = ["process_and_filter_bbs_lib.h"],
+    deps = [
+        "//gematria/llvm:disassembler",
+        "//gematria/llvm:llvm_architecture_support",
+        "//gematria/utils:string",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/gematria/datasets/process_and_filter_bbs.cc
+++ b/gematria/datasets/process_and_filter_bbs.cc
@@ -58,8 +58,9 @@ int main(int Argc, char **Argv) {
   std::ifstream InputFileStream(InputFile);
   std::ofstream OutputFileStream(OutputFile);
   for (std::string Line; std::getline(InputFileStream, Line);) {
-    Expected<std::string> ProcessedBlockOrErr = BBProcessor.processBasicBlock(
-        Line, InputFile, FilterMemoryAccessingBlocks);
+    Expected<std::string> ProcessedBlockOrErr =
+        BBProcessor.removeRiskyInstructions(Line, InputFile,
+                                            FilterMemoryAccessingBlocks);
     if (!ProcessedBlockOrErr) ExitOnErr(ProcessedBlockOrErr.takeError());
 
     OutputFileStream << *ProcessedBlockOrErr << "\n";

--- a/gematria/datasets/process_and_filter_bbs.cc
+++ b/gematria/datasets/process_and_filter_bbs.cc
@@ -15,13 +15,7 @@
 #include <fstream>
 #include <limits>
 
-#include "X86.h"
-#include "X86InstrInfo.h"
-#include "X86RegisterInfo.h"
-#include "gematria/llvm/disassembler.h"
-#include "gematria/llvm/llvm_architecture_support.h"
-#include "gematria/utils/string.h"
-#include "llvm/ADT/StringExtras.h"
+#include "gematria/datasets/process_and_filter_bbs_lib.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 
@@ -52,69 +46,20 @@ static cl::opt<unsigned> ReportProgressEvery(
     cl::desc("The interval at which to report progress in blocks"),
     cl::init(std::numeric_limits<unsigned>::max()), cl::cat(ProcessFilterCat));
 
-Expected<std::string> processBasicBlock(
-    const std::string &BasicBlock,
-    const gematria::LlvmArchitectureSupport &LLVMSupport,
-    MCInstPrinter &MachineInstructionPrinter, const StringRef FileName) {
-  // TODO(boomanaiden154): Update this to use llvm::Expected once
-  // gematria::ParseHex is refactored to return llvm::Expected.
-  auto MachineCodeHex = gematria::ParseHexString(BasicBlock);
-  if (!MachineCodeHex.has_value()) {
-    return createFileError(
-        FileName,
-        make_error<StringError>(
-            llvm::Twine("Could not parse: '").concat(BasicBlock).concat("'"),
-            std::make_error_code(std::errc::invalid_argument)));
-  }
-
-  Expected<std::vector<gematria::DisassembledInstruction>>
-      DisassembledInstructionsOrErr = gematria::DisassembleAllInstructions(
-          LLVMSupport.mc_disassembler(), LLVMSupport.mc_instr_info(),
-          LLVMSupport.mc_register_info(), LLVMSupport.mc_subtarget_info(),
-          MachineInstructionPrinter, 0, *MachineCodeHex);
-
-  if (!DisassembledInstructionsOrErr)
-    return createFileError(FileName, DisassembledInstructionsOrErr.takeError());
-
-  std::string OutputBlock;
-
-  for (const gematria::DisassembledInstruction &Instruction :
-       *DisassembledInstructionsOrErr) {
-    MCInstrDesc InstDesc =
-        LLVMSupport.mc_instr_info().get(Instruction.mc_inst.getOpcode());
-    // TODO(boomanaiden154): This filtering is a bit simplistic currently. We
-    // should probably be using MCInsrtDesc::hasUnmodeledSideEffects, but this
-    // needs to be evaluated at scale.
-    if (Instruction.mc_inst.getOpcode() == X86::SYSCALL) continue;
-    if (InstDesc.isReturn() || InstDesc.isCall() || InstDesc.isBranch())
-      continue;
-    if (FilterMemoryAccessingBlocks &&
-        (InstDesc.mayLoad() || InstDesc.mayStore()))
-      continue;
-    OutputBlock += toHex(Instruction.machine_code);
-  }
-
-  return OutputBlock;
-}
-
 int main(int Argc, char **Argv) {
   cl::ParseCommandLineOptions(Argc, Argv, "process_and_filter_bbs");
 
   ExitOnError ExitOnErr("process_and_filter_bbs error: ");
 
-  const std::unique_ptr<gematria::LlvmArchitectureSupport> LLVMSupport =
-      gematria::LlvmArchitectureSupport::X86_64();
-
-  std::unique_ptr<MCInstPrinter> MachineInstructionPrinter =
-      LLVMSupport->CreateMCInstPrinter(0);
+  gematria::BBProcessorFilter BBProcessor;
 
   unsigned LineCount = 0;
 
   std::ifstream InputFileStream(InputFile);
   std::ofstream OutputFileStream(OutputFile);
   for (std::string Line; std::getline(InputFileStream, Line);) {
-    Expected<std::string> ProcessedBlockOrErr = processBasicBlock(
-        Line, *LLVMSupport, *MachineInstructionPrinter, InputFile);
+    Expected<std::string> ProcessedBlockOrErr = BBProcessor.processBasicBlock(
+        Line, InputFile, FilterMemoryAccessingBlocks);
     if (!ProcessedBlockOrErr) ExitOnErr(ProcessedBlockOrErr.takeError());
 
     OutputFileStream << *ProcessedBlockOrErr << "\n";

--- a/gematria/datasets/process_and_filter_bbs_lib.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib.cc
@@ -24,12 +24,11 @@ using namespace llvm;
 
 namespace gematria {
 
-BBProcessorFilter::BBProcessorFilter() {
-  LLVMSupport = LlvmArchitectureSupport::X86_64();
-  InstructionPrinter = LLVMSupport->CreateMCInstPrinter(0);
-}
+BBProcessorFilter::BBProcessorFilter()
+    : LLVMSupport(LlvmArchitectureSupport::X86_64()),
+      InstructionPrinter(LLVMSupport->CreateMCInstPrinter(0)) {}
 
-Expected<std::string> BBProcessorFilter::processBasicBlock(
+Expected<std::string> BBProcessorFilter::removeRiskyInstructions(
     const StringRef BasicBlock, const StringRef Filename,
     bool FilterMemoryAccessingBlocks) {
   // TODO(boomanaiden154): Update this to use llvm::Expected once

--- a/gematria/datasets/process_and_filter_bbs_lib.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib.cc
@@ -14,6 +14,15 @@
 
 #include "gematria/datasets/process_and_filter_bbs_lib.h"
 
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "/gematria/external/llvm-project/llvm/include/llvm/ADT/StringRef.h"
+#include "/gematria/external/llvm-project/llvm/include/llvm/ADT/Twine.h"
+#include "/gematria/external/llvm-project/llvm/include/llvm/MC/MCInstrDesc.h"
+#include "/gematria/external/llvm-project/llvm/include/llvm/Support/Error.h"
+#include "/gematria/external/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 #include "X86InstrInfo.h"
 #include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"

--- a/gematria/datasets/process_and_filter_bbs_lib.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib.cc
@@ -18,16 +18,16 @@
 #include <system_error>
 #include <vector>
 
-#include "/gematria/external/llvm-project/llvm/include/llvm/ADT/StringRef.h"
-#include "/gematria/external/llvm-project/llvm/include/llvm/ADT/Twine.h"
-#include "/gematria/external/llvm-project/llvm/include/llvm/MC/MCInstrDesc.h"
-#include "/gematria/external/llvm-project/llvm/include/llvm/Support/Error.h"
-#include "/gematria/external/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 #include "X86InstrInfo.h"
 #include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/utils/string.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/include/llvm/ADT/StringRef.h"
+#include "llvm/include/llvm/ADT/Twine.h"
+#include "llvm/include/llvm/MC/MCInstrDesc.h"
+#include "llvm/include/llvm/Support/Error.h"
+#include "llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 
 using namespace llvm;
 

--- a/gematria/datasets/process_and_filter_bbs_lib.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib.cc
@@ -1,0 +1,74 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/process_and_filter_bbs_lib.h"
+
+#include "X86InstrInfo.h"
+#include "gematria/llvm/disassembler.h"
+#include "gematria/llvm/llvm_architecture_support.h"
+#include "gematria/utils/string.h"
+#include "llvm/ADT/StringExtras.h"
+
+namespace gematria {
+
+BBProcessorFilter::BBProcessorFilter() {
+  LLVMSupport = LlvmArchitectureSupport::X86_64();
+  InstructionPrinter = LLVMSupport->CreateMCInstPrinter(0);
+}
+
+Expected<std::string> BBProcessorFilter::processBasicBlock(
+    const StringRef BasicBlock, const StringRef Filename,
+    bool FilterMemoryAccessingBlocks) {
+  // TODO(boomanaiden154): Update this to use llvm::Expected once
+  // gematria::ParseHex is refactored to return llvm::Expected.
+  auto MachineCodeHex = gematria::ParseHexString(BasicBlock);
+  if (!MachineCodeHex.has_value()) {
+    return createFileError(
+        Filename,
+        make_error<StringError>(
+            llvm::Twine("Could not parse: '").concat(BasicBlock).concat("'"),
+            std::make_error_code(std::errc::invalid_argument)));
+  }
+
+  Expected<std::vector<gematria::DisassembledInstruction>>
+      DisassembledInstructionsOrErr = gematria::DisassembleAllInstructions(
+          LLVMSupport->mc_disassembler(), LLVMSupport->mc_instr_info(),
+          LLVMSupport->mc_register_info(), LLVMSupport->mc_subtarget_info(),
+          *InstructionPrinter, 0, *MachineCodeHex);
+
+  if (!DisassembledInstructionsOrErr)
+    return createFileError(Filename, DisassembledInstructionsOrErr.takeError());
+
+  std::string OutputBlock;
+
+  for (const gematria::DisassembledInstruction &Instruction :
+       *DisassembledInstructionsOrErr) {
+    MCInstrDesc InstDesc =
+        LLVMSupport->mc_instr_info().get(Instruction.mc_inst.getOpcode());
+    // TODO(boomanaiden154): This filtering is a bit simplistic currently. We
+    // should probably be using MCInsrtDesc::hasUnmodeledSideEffects, but this
+    // needs to be evaluated at scale.
+    if (Instruction.mc_inst.getOpcode() == X86::SYSCALL) continue;
+    if (InstDesc.isReturn() || InstDesc.isCall() || InstDesc.isBranch())
+      continue;
+    if (FilterMemoryAccessingBlocks &&
+        (InstDesc.mayLoad() || InstDesc.mayStore()))
+      continue;
+    OutputBlock += toHex(Instruction.machine_code);
+  }
+
+  return OutputBlock;
+}
+
+}  // namespace gematria

--- a/gematria/datasets/process_and_filter_bbs_lib.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib.cc
@@ -20,6 +20,8 @@
 #include "gematria/utils/string.h"
 #include "llvm/ADT/StringExtras.h"
 
+using namespace llvm;
+
 namespace gematria {
 
 BBProcessorFilter::BBProcessorFilter() {

--- a/gematria/datasets/process_and_filter_bbs_lib.h
+++ b/gematria/datasets/process_and_filter_bbs_lib.h
@@ -16,21 +16,19 @@
 
 #include "gematria/llvm/llvm_architecture_support.h"
 
-using namespace llvm;
-
 namespace gematria {
 
 class BBProcessorFilter {
  public:
   explicit BBProcessorFilter();
 
-  Expected<std::string> processBasicBlock(const StringRef BasicBlock,
-                                          const StringRef Filename,
-                                          bool FilterMemoryAccessingBlocks);
+  llvm::Expected<std::string> processBasicBlock(
+      const llvm::StringRef BasicBlock, const llvm::StringRef Filename,
+      bool FilterMemoryAccessingBlocks);
 
  private:
   std::unique_ptr<LlvmArchitectureSupport> LLVMSupport;
-  std::unique_ptr<MCInstPrinter> InstructionPrinter;
+  std::unique_ptr<llvm::MCInstPrinter> InstructionPrinter;
 };
 
 }  // namespace gematria

--- a/gematria/datasets/process_and_filter_bbs_lib.h
+++ b/gematria/datasets/process_and_filter_bbs_lib.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <string>
 
 #include "gematria/llvm/llvm_architecture_support.h"

--- a/gematria/datasets/process_and_filter_bbs_lib.h
+++ b/gematria/datasets/process_and_filter_bbs_lib.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "gematria/llvm/llvm_architecture_support.h"
+
+using namespace llvm;
+
+namespace gematria {
+
+class BBProcessorFilter {
+ public:
+  explicit BBProcessorFilter();
+
+  Expected<std::string> processBasicBlock(const StringRef BasicBlock,
+                                          const StringRef Filename,
+                                          bool FilterMemoryAccessingBlocks);
+
+ private:
+  std::unique_ptr<LlvmArchitectureSupport> LLVMSupport;
+  std::unique_ptr<MCInstPrinter> InstructionPrinter;
+};
+
+}  // namespace gematria

--- a/gematria/datasets/process_and_filter_bbs_lib.h
+++ b/gematria/datasets/process_and_filter_bbs_lib.h
@@ -15,14 +15,24 @@
 #include <string>
 
 #include "gematria/llvm/llvm_architecture_support.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/Support/Error.h"
 
 namespace gematria {
 
+// BBProcessorFilter is used for processing and filtering raw basic blocks
+// extracted directly from applications. It contains functions to process
+// individual blocks with the class containing the relevant stateful objects
+// needed for processing.
 class BBProcessorFilter {
  public:
-  explicit BBProcessorFilter();
+  BBProcessorFilter();
 
-  llvm::Expected<std::string> processBasicBlock(
+  // Removes instructions that might be considered risky in that they
+  // might violate modeling assumptions explicitly or have unmodeled
+  // side effects that might cause problems
+  llvm::Expected<std::string> removeRiskyInstructions(
       const llvm::StringRef BasicBlock, const llvm::StringRef Filename,
       bool FilterMemoryAccessingBlocks);
 


### PR DESCRIPTION
This will enable the addition of unittests to verify the functionality of the script along with the addition of python bindings so that this tooling can be easily used from within a beam pipeline.