### PR TITLE
Add MissingIncludes to clangd config

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+Diagnostics:
+  UnusedIncludes: Strict
+  MissingIncludes: Strict


### PR DESCRIPTION
This patch adds the MissingIncludes option to the clangd config so that IWYU violations are warned about in the IDE, assuming it uses clangd as the LSP.