### PR TITLE
Renamed AccessedAddrs BlockAnnotations

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -96,7 +96,7 @@ ABSL_FLAG(unsigned, max_annotation_attempts, 50,
           "The maximum number of times to attempt to annotate a block before "
           "giving up.");
 
-absl::StatusOr<gematria::AccessedAddrs> GetAccessedAddrs(
+absl::StatusOr<gematria::BlockAnnotations> GetAccessedAddrs(
     absl::Span<const uint8_t> basic_block,
     gematria::ExegesisAnnotator* exegesis_annotator,
     const unsigned max_annotation_attempts,
@@ -112,7 +112,7 @@ absl::StatusOr<gematria::AccessedAddrs> GetAccessedAddrs(
               llvm::ArrayRef(basic_block.begin(), basic_block.end()),
               max_annotation_attempts));
     case AnnotatorType::kNone:
-      return gematria::AccessedAddrs();
+      return gematria::BlockAnnotations();
   }
   return absl::InvalidArgumentError("unknown annotator type");
 }
@@ -138,7 +138,7 @@ bool WriteJsonFile(llvm::json::Array to_write, size_t json_file_number,
 }
 
 struct AnnotatedBlock {
-  gematria::AccessedAddrs accessed_addrs;
+  gematria::BlockAnnotations accessed_addrs;
   gematria::BasicBlockProto basic_block_proto;
   std::optional<unsigned> loop_register;
 };

--- a/gematria/datasets/find_accessed_addrs.h
+++ b/gematria/datasets/find_accessed_addrs.h
@@ -53,7 +53,7 @@ struct RegisterAndValue {
   int64_t register_value;
 };
 
-struct AccessedAddrs {
+struct BlockAnnotations {
   uintptr_t code_location;
   size_t block_size;
   uint64_t block_contents;
@@ -64,7 +64,7 @@ struct AccessedAddrs {
 // Given a basic block of code, attempt to determine what addresses that code
 // accesses. This is done by executing the code in a new process, so the code
 // must match the architecture on which this function is executed.
-absl::StatusOr<AccessedAddrs> FindAccessedAddrs(
+absl::StatusOr<BlockAnnotations> FindAccessedAddrs(
     absl::Span<const uint8_t> basic_block,
     LlvmArchitectureSupport &llvm_arch_support);
 

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -85,7 +85,7 @@ Expected<std::unique_ptr<ExegesisAnnotator>> ExegesisAnnotator::create(
       ExegesisState, std::move(*RunnerOrErr), std::move(SnipRepetitor)));
 }
 
-Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
+Expected<BlockAnnotations> ExegesisAnnotator::findAccessedAddrs(
     ArrayRef<uint8_t> BasicBlock, unsigned MaxAnnotationAttempts) {
   Expected<std::vector<DisassembledInstruction>> DisInstructions =
       DisassembleAllInstructions(*MachineDisassembler, State.getInstrInfo(),
@@ -100,7 +100,7 @@ Expected<AccessedAddrs> ExegesisAnnotator::findAccessedAddrs(
   for (const auto &DisInstruction : *DisInstructions)
     Instructions.push_back(DisInstruction.mc_inst);
 
-  AccessedAddrs MemAnnotations;
+  BlockAnnotations MemAnnotations;
   MemAnnotations.code_location = 0;
   MemAnnotations.block_size = 4096;
 

--- a/gematria/datasets/find_accessed_addrs_exegesis.h
+++ b/gematria/datasets/find_accessed_addrs_exegesis.h
@@ -49,8 +49,8 @@ class ExegesisAnnotator {
  public:
   static Expected<std::unique_ptr<ExegesisAnnotator>> create(
       LLVMState &ExegesisState);
-  Expected<AccessedAddrs> findAccessedAddrs(ArrayRef<uint8_t> BasicBlock,
-                                            unsigned MaxAnnotationAttempts);
+  Expected<BlockAnnotations> findAccessedAddrs(ArrayRef<uint8_t> BasicBlock,
+                                               unsigned MaxAnnotationAttempts);
 };
 
 }  // namespace gematria

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -69,7 +69,7 @@ class FindAccessedAddrsExegesisTest : public testing::Test {
     return std::string(Code);
   }
 
-  llvm::Expected<AccessedAddrs> FindAccessedAddrsExegesis(
+  llvm::Expected<BlockAnnotations> FindAccessedAddrsExegesis(
       std::string_view TextualAssembly) {
     auto Code = Assemble(TextualAssembly);
     auto Annotator = cantFail(ExegesisAnnotator::create(State));
@@ -89,7 +89,7 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisNoAccess) {
     movq %r11, %r12
   )asm");
   ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
-  AccessedAddrs Result = *AddrsOrErr;
+  BlockAnnotations Result = *AddrsOrErr;
   EXPECT_EQ(Result.accessed_blocks.size(), 0);
 }
 
@@ -99,7 +99,7 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisOneAccess) {
     movq (%rax), %rax
   )asm");
   ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
-  AccessedAddrs Result = *AddrsOrErr;
+  BlockAnnotations Result = *AddrsOrErr;
   EXPECT_EQ(Result.accessed_blocks.size(), 1);
   EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
 }
@@ -110,7 +110,7 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisNotPageAligned) {
     movq (%rax), %rax
   )asm");
   ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
-  AccessedAddrs Result = *AddrsOrErr;
+  BlockAnnotations Result = *AddrsOrErr;
   EXPECT_EQ(Result.accessed_blocks.size(), 1);
   EXPECT_EQ(Result.accessed_blocks[0], 0x10000);
 }

--- a/gematria/datasets/find_accessed_addrs_test.cc
+++ b/gematria/datasets/find_accessed_addrs_test.cc
@@ -100,7 +100,7 @@ class FindAccessedAddrsTest : public testing::Test {
     return std::string(code);
   }
 
-  absl::StatusOr<AccessedAddrs> FindAccessedAddrsAsm(
+  absl::StatusOr<BlockAnnotations> FindAccessedAddrsAsm(
       std::string_view textual_assembly) {
     auto code = Assemble(textual_assembly);
     auto span = absl::MakeConstSpan(
@@ -111,7 +111,7 @@ class FindAccessedAddrsTest : public testing::Test {
 
 TEST_F(FindAccessedAddrsTest, BasicMov) {
   EXPECT_THAT(FindAccessedAddrsAsm("mov [0x10000], eax"),
-              IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks,
+              IsOkAndHolds(Field(&BlockAnnotations::accessed_blocks,
                                  ElementsAre(0x10000))));
 }
 
@@ -142,7 +142,7 @@ TEST_F(FindAccessedAddrsTest, DISABLED_SingleAddressRandomTests) {
       mov ebx, [rax]
     )asm",
                                 addr);
-    const absl::StatusOr<AccessedAddrs> result = FindAccessedAddrsAsm(code);
+    const absl::StatusOr<BlockAnnotations> result = FindAccessedAddrsAsm(code);
     ASSERT_OK(result.status());
 
     EXPECT_THAT(result->accessed_blocks,
@@ -153,8 +153,9 @@ TEST_F(FindAccessedAddrsTest, DISABLED_SingleAddressRandomTests) {
 }
 
 TEST_F(FindAccessedAddrsTest, NoMemoryAccesses) {
-  EXPECT_THAT(FindAccessedAddrsAsm("mov eax, ebx"),
-              IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks, IsEmpty())));
+  EXPECT_THAT(
+      FindAccessedAddrsAsm("mov eax, ebx"),
+      IsOkAndHolds(Field(&BlockAnnotations::accessed_blocks, IsEmpty())));
 }
 
 TEST_F(FindAccessedAddrsTest, MultipleAccesses) {
@@ -162,7 +163,7 @@ TEST_F(FindAccessedAddrsTest, MultipleAccesses) {
     mov [0x10000], eax
     mov [0x20000], eax
   )asm"),
-              IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks,
+              IsOkAndHolds(Field(&BlockAnnotations::accessed_blocks,
                                  ElementsAre(0x10000, 0x20000))));
 }
 
@@ -171,7 +172,7 @@ TEST_F(FindAccessedAddrsTest, AccessFromRegister) {
     mov [eax], eax
     mov [r11+r12], eax
   )asm"),
-              IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks,
+              IsOkAndHolds(Field(&BlockAnnotations::accessed_blocks,
                                  ElementsAre(0x15000, 0x2a000))));
 }
 
@@ -180,7 +181,7 @@ TEST_F(FindAccessedAddrsTest, DoubleIndirection) {
     mov rax, [0x10000]
     mov rbx, [rax]
   )asm"),
-              IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks,
+              IsOkAndHolds(Field(&BlockAnnotations::accessed_blocks,
                                  ElementsAre(0x10000, 0x0000000800000000))));
 }
 
@@ -193,7 +194,7 @@ TEST_F(FindAccessedAddrsTest, DivideByPointee) {
     mov ebx, [rcx]
     idiv ebx
   )asm"),
-              IsOkAndHolds(Field(&AccessedAddrs::accessed_blocks,
+              IsOkAndHolds(Field(&BlockAnnotations::accessed_blocks,
                                  ElementsAre(0x15000))));
 }
 


### PR DESCRIPTION
Now that we are having the find_accessed_addrs scripts add data like initial register values, memory values, and more, just calling the struct they procued AccessedAddrs makes less sense. This patch changes the name to BlockAnnotations to better capture what is stored within the struct.