### PR TITLE
Fix IWYU warnings in Datasets

### DIFF
--- a/gematria/datasets/basic_block_utils.cc
+++ b/gematria/datasets/basic_block_utils.cc
@@ -14,13 +14,18 @@
 
 #include "gematria/datasets/basic_block_utils.h"
 
+#include <optional>
 #include <set>
+#include <vector>
 
-#include "X86.h"
-#include "X86InstrInfo.h"
-#include "X86RegisterInfo.h"
+#include "gematria/llvm/disassembler.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 
 using namespace llvm;
 

--- a/gematria/datasets/basic_block_utils.h
+++ b/gematria/datasets/basic_block_utils.h
@@ -17,6 +17,7 @@
 #ifndef THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_
 #define THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BASIC_BLOCK_UTILS_H_
 
+#include <optional>
 #include <vector>
 
 #include "gematria/llvm/disassembler.h"

--- a/gematria/datasets/basic_block_utils_test.cc
+++ b/gematria/datasets/basic_block_utils_test.cc
@@ -14,14 +14,20 @@
 
 #include "gematria/datasets/basic_block_utils.h"
 
-#include "X86.h"
-#include "X86InstrInfo.h"
-#include "X86RegisterInfo.h"
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "absl/log/check.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"
-#include "gematria/testing/matchers.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 
 using testing::AnyOf;
 using testing::IsEmpty;

--- a/gematria/datasets/bhive_importer.cc
+++ b/gematria/datasets/bhive_importer.cc
@@ -15,6 +15,7 @@
 #include "gematria/datasets/bhive_importer.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -26,6 +27,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "gematria/basic_block/basic_block_protos.h"

--- a/gematria/datasets/bhive_importer.h
+++ b/gematria/datasets/bhive_importer.h
@@ -18,6 +18,7 @@
 #ifndef THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BHIVE_IMPORTER_H_
 #define THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_BHIVE_IMPORTER_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string_view>

--- a/gematria/datasets/bhive_importer_test.cc
+++ b/gematria/datasets/bhive_importer_test.cc
@@ -15,20 +15,25 @@
 #include "gematria/datasets/bhive_importer.h"
 
 #include <memory>
+#include <vector>
 
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "gematria/llvm/canonicalizer.h"
+#include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/testing/matchers.h"
 #include "gematria/utils/string.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/Support/Error.h"
 
 namespace gematria {
 namespace {
 
 class BHiveImporterTest : public ::testing::Test {
  protected:
-  static constexpr absl::string_view kLlvmTriple = "x86_64-unknown-unknown";
   static constexpr absl::string_view kSourceName = "bhive: skl";
 
   static constexpr double kScaling = 1.0 / 100.0;

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
+#include <utility>
 #include <vector>
 
-#include "X86RegisterInfo.h"
 #include "X86Subtarget.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
-#include "gematria/datasets/basic_block_utils.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "gematria/datasets/bhive_importer.h"
 #include "gematria/datasets/find_accessed_addrs.h"
 #include "gematria/datasets/find_accessed_addrs_exegesis.h"
@@ -33,10 +39,19 @@
 #include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/llvm/llvm_to_absl.h"
+#include "gematria/proto/basic_block.pb.h"
 #include "gematria/utils/string.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCRegister.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 
 constexpr std::string_view kRegDefPrefix = "# LLVM-EXEGESIS-DEFREG ";

--- a/gematria/datasets/exegesis_benchmark.cc
+++ b/gematria/datasets/exegesis_benchmark.cc
@@ -12,16 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "X86.h"
-#include "X86InstrInfo.h"
-#include "X86RegisterInfo.h"
 #include "gematria/llvm/disassembler.h"
 #include "gematria/utils/string.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCInst.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Errc.h"
@@ -29,9 +36,15 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkCode.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkResult.h"
 #include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
 #include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
+#include "llvm/tools/llvm-exegesis/lib/PerfHelper.h"
+#include "llvm/tools/llvm-exegesis/lib/RegisterValue.h"
 #include "llvm/tools/llvm-exegesis/lib/ResultAggregator.h"
+#include "llvm/tools/llvm-exegesis/lib/SnippetRepetitor.h"
 #include "llvm/tools/llvm-exegesis/lib/Target.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 

--- a/gematria/datasets/extract_bbs_from_obj.cc
+++ b/gematria/datasets/extract_bbs_from_obj.cc
@@ -12,10 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "gematria/datasets/extract_bbs_from_obj_lib.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 

--- a/gematria/datasets/extract_bbs_from_obj_lib.cc
+++ b/gematria/datasets/extract_bbs_from_obj_lib.cc
@@ -14,12 +14,25 @@
 
 #include "extract_bbs_from_obj_lib.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Object/Binary.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ELFTypes.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 
 using namespace llvm;

--- a/gematria/datasets/find_accessed_addrs.cc
+++ b/gematria/datasets/find_accessed_addrs.cc
@@ -15,9 +15,13 @@
 #include "gematria/datasets/find_accessed_addrs.h"
 
 #include <bits/types/siginfo_t.h>
+#include <sched.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/ptrace.h>
+#include <sys/types.h>
 #include <sys/user.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -32,9 +36,9 @@
 #include <cstring>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "X86.h"
 #include "absl/random/random.h"
 #include "absl/random/uniform_int_distribution.h"
 #include "absl/status/status.h"
@@ -49,8 +53,7 @@
 #include "gematria/llvm/llvm_to_absl.h"
 #include "lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/MC/MCInst.h"
-#include "llvm/MC/MCRegister.h"
+#include "llvm/Support/Error.h"
 
 namespace gematria {
 namespace {

--- a/gematria/datasets/find_accessed_addrs.h
+++ b/gematria/datasets/find_accessed_addrs.h
@@ -15,9 +15,9 @@
 #ifndef THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_FIND_ACCESSED_ADDRS_H_
 #define THIRD_PARTY_GEMATRIA_GEMATRIA_DATASETS_FIND_ACCESSED_ADDRS_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
-#include <type_traits>
 #include <vector>
 
 #include "absl/status/statusor.h"

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -20,13 +20,31 @@
 
 #include <unistd.h>
 
-#include "X86.h"
-#include "X86InstrInfo.h"
-#include "X86RegisterInfo.h"
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "find_accessed_addrs.h"
 #include "gematria/datasets/basic_block_utils.h"
 #include "gematria/llvm/disassembler.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/Error.h"
+#include "llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkCode.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkResult.h"
 #include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
+#include "llvm/tools/llvm-exegesis/lib/Error.h"
 #include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
+#include "llvm/tools/llvm-exegesis/lib/PerfHelper.h"
+#include "llvm/tools/llvm-exegesis/lib/RegisterValue.h"
+#include "llvm/tools/llvm-exegesis/lib/SnippetRepetitor.h"
 #include "llvm/tools/llvm-exegesis/lib/Target.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 

--- a/gematria/datasets/find_accessed_addrs_exegesis.h
+++ b/gematria/datasets/find_accessed_addrs_exegesis.h
@@ -16,17 +16,21 @@
 #define GEMATRIA_DATASETS_FIND_ACCESSED_ADDRS_EXEGESIS_H_
 
 #include <cstdint>
-#include <vector>
+#include <memory>
 
 // Use the absolute path for headers from llvm-exegesis as there is no
 // canonical include path within LLVM as they are not properly exposed through
 // a library and could potentially be confused with other LLVM includes.
 
 #include "gematria/datasets/find_accessed_addrs.h"
-#include "gematria/llvm/llvm_architecture_support.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDisassembler/MCDisassembler.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/Support/Error.h"
 #include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
 #include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
+#include "llvm/tools/llvm-exegesis/lib/SnippetRepetitor.h"
 
 using namespace llvm;
 using namespace llvm::exegesis;

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -14,15 +14,29 @@
 
 #include "gematria/datasets/find_accessed_addrs_exegesis.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
 // Use the absolute path for headers from llvm-exegesis as there is no
 // canonical include path within LLVM as they are not properly exposed through
 // a library and could potentially be confused with other LLVM includes.
 
 #include "absl/log/check.h"
+#include "absl/memory/memory.h"
+#include "find_accessed_addrs.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gtest/gtest.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/Support/Error.h"
+#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 
 using namespace llvm;

--- a/gematria/datasets/find_accessed_addrs_test.cc
+++ b/gematria/datasets/find_accessed_addrs_test.cc
@@ -17,24 +17,21 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/random/distributions.h"
 #include "absl/random/random.h"
-#include "absl/random/seed_sequences.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/str_join.h"
 #include "absl/types/span.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/testing/matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/MC/MCAsmInfo.h"

--- a/gematria/datasets/process_and_filter_bbs.cc
+++ b/gematria/datasets/process_and_filter_bbs.cc
@@ -16,9 +16,9 @@
 #include <limits>
 #include <string>
 
-#include "llvm/Support/Debug.h"
 #include "gematria/datasets/process_and_filter_bbs_lib.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 
 using namespace llvm;

--- a/gematria/datasets/process_and_filter_bbs.cc
+++ b/gematria/datasets/process_and_filter_bbs.cc
@@ -14,7 +14,9 @@
 
 #include <fstream>
 #include <limits>
+#include <string>
 
+#include "llvm/Support/Debug.h"
 #include "gematria/datasets/process_and_filter_bbs_lib.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"

--- a/gematria/datasets/process_and_filter_bbs_lib.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib.cc
@@ -18,7 +18,6 @@
 #include <system_error>
 #include <vector>
 
-#include "X86InstrInfo.h"
 #include "gematria/llvm/disassembler.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/utils/string.h"

--- a/gematria/datasets/python/bhive_importer.cc
+++ b/gematria/datasets/python/bhive_importer.cc
@@ -23,8 +23,8 @@
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"
 #include "pybind11_abseil/import_status_module.h"
-#include "pybind11_abseil/status_casters.h"
-#include "pybind11_protobuf/native_proto_caster.h"
+#include "pybind11_abseil/status_casters.h"         // IWYU pragma: keep
+#include "pybind11_protobuf/native_proto_caster.h"  // IWYU pragma: keep
 
 namespace gematria {
 

--- a/gematria/datasets/python/extract_bbs_from_obj.cc
+++ b/gematria/datasets/python/extract_bbs_from_obj.cc
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string_view>
+
 #include "gematria/datasets/extract_bbs_from_obj_lib.h"
 #include "gematria/llvm/llvm_to_absl.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "pybind11/cast.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
+#include "pybind11/pytypes.h"
+#include "pybind11/stl.h"  // IWYU pragma: keep
 #include "pybind11_abseil/import_status_module.h"
-#include "pybind11_abseil/status_casters.h"
+#include "pybind11_abseil/status_casters.h"  // IWYU pragma: keep
 
 namespace gematria {
 


### PR DESCRIPTION
This patch fixes IWYU warnings under the dataset directory by using clangd to update all the headers within the C++/C files.