### PR TITLE
Add python bindings for bhive_to_exegesis

### DIFF
--- a/gematria/datasets/BUILD.bazel
+++ b/gematria/datasets/BUILD.bazel
@@ -44,6 +44,7 @@ cc_library(
     name = "bhive_to_exegesis",
     srcs = ["bhive_to_exegesis.cc"],
     hdrs = ["bhive_to_exegesis.h"],
+    visibility = ["//:internal_users"],
     deps = [
         ":bhive_importer",
         ":find_accessed_addrs",

--- a/gematria/datasets/python/BUILD.bazel
+++ b/gematria/datasets/python/BUILD.bazel
@@ -121,3 +121,24 @@ gematria_py_test(
         ":process_and_filter_bbs",
     ],
 )
+
+gematria_pybind_extension(
+    name = "bhive_to_exegesis",
+    srcs = ["bhive_to_exegesis.cc"],
+    visibility = ["//:internal_users"],
+    deps = [
+        "//gematria/datasets:bhive_to_exegesis",
+        "//gematria/llvm:llvm_to_absl",
+        "@pybind11_abseil_repo//pybind11_abseil:status_casters",
+    ],
+)
+
+gematria_py_test(
+    name = "bhive_to_exegesis_test",
+    size = "small",
+    srcs = ["bhive_to_exegesis_test.py"],
+    deps = [
+        ":bhive_to_exegesis",
+        "//gematria/llvm/python:llvm_architecture_support",
+    ],
+)

--- a/gematria/datasets/python/bhive_to_exegesis.cc
+++ b/gematria/datasets/python/bhive_to_exegesis.cc
@@ -1,0 +1,70 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/bhive_to_exegesis.h"
+
+#include <string>
+
+#include "gematria/llvm/llvm_architecture_support.h"
+#include "gematria/llvm/llvm_to_absl.h"
+#include "llvm-c/Target.h"
+#include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
+#include "pybind11/detail/common.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"  // IWYU pragma: keep
+#include "pybind11_abseil/import_status_module.h"
+#include "pybind11_abseil/status_casters.h"  // IWYU pragma: keep
+
+namespace gematria {
+
+namespace py = ::pybind11;
+
+PYBIND11_MODULE(bhive_to_exegesis, m) {
+  m.doc() = "Code for annotating baisc blocks.";
+
+  py::google::ImportStatusModule();
+
+  py::enum_<BHiveToExegesis::AnnotatorType>(m, "AnnotatorType")
+      .value("exegesis", BHiveToExegesis::AnnotatorType::kExegesis)
+      .value("fast", BHiveToExegesis::AnnotatorType::kFast)
+      .value("none", BHiveToExegesis::AnnotatorType::kNone)
+      .export_values();
+
+  py::class_<AnnotatedBlock>(m, "AnnotatedBlock");
+
+  py::class_<BHiveToExegesis>(m, "BHiveToExegesis")
+      .def("create",
+           [](LlvmArchitectureSupport& ArchitectureSupport) {
+             LLVMInitializeX86Target();
+             LLVMInitializeX86TargetInfo();
+             LLVMInitializeX86TargetMC();
+             LLVMInitializeX86AsmPrinter();
+             LLVMInitializeX86AsmParser();
+             LLVMInitializeX86Disassembler();
+             InitializeX86ExegesisTarget();
+
+             return LlvmExpectedToStatusOr(
+                 BHiveToExegesis::create(ArchitectureSupport));
+           })
+      .def("annotate_basic_block",
+           [](BHiveToExegesis& Self, std::string BasicBlockHex,
+              BHiveToExegesis::AnnotatorType AnnotatorType,
+              unsigned MaxAnnotationAttempts) {
+             return Self
+                 .annotateBasicBlock(BasicBlockHex, AnnotatorType,
+                                     MaxAnnotationAttempts);
+           });
+}
+
+}  // namespace gematria

--- a/gematria/datasets/python/bhive_to_exegesis.cc
+++ b/gematria/datasets/python/bhive_to_exegesis.cc
@@ -20,6 +20,7 @@
 #include "gematria/llvm/llvm_to_absl.h"
 #include "llvm-c/Target.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
+#include "pybind11/cast.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"  // IWYU pragma: keep
@@ -57,14 +58,35 @@ PYBIND11_MODULE(bhive_to_exegesis, m) {
              return LlvmExpectedToStatusOr(
                  BHiveToExegesis::create(ArchitectureSupport));
            })
-      .def("annotate_basic_block",
-           [](BHiveToExegesis& Self, std::string BasicBlockHex,
-              BHiveToExegesis::AnnotatorType AnnotatorType,
-              unsigned MaxAnnotationAttempts) {
-             return Self
-                 .annotateBasicBlock(BasicBlockHex, AnnotatorType,
-                                     MaxAnnotationAttempts);
-           });
+      .def(
+          "annotate_basic_block",
+          [](BHiveToExegesis& Self, std::string BasicBlockHex,
+             BHiveToExegesis::AnnotatorType AnnotatorType,
+             unsigned MaxAnnotationAttempts) {
+            return Self.annotateBasicBlock(BasicBlockHex, AnnotatorType,
+                                           MaxAnnotationAttempts);
+          },
+          py::arg("basic_block_hex"), py::arg("annotator_type"),
+          py::arg("max_annotation_attempts"),
+          R"(Annotates a basic block, providing memory and register info.
+
+          Takes a single basic block and annotates it, providing information
+          on initial register values and the memory setup that should be used
+          in order to execute the block.
+
+          Args:
+            basic_block_hex: The basic block in hexadecimal format.
+            annotator_type: The annotator to use.
+            max_annotation_attempts: The maximum number of times to try
+              to find an appropriate memory setup for the block before
+              giving up.
+            
+          Returns:
+            An AnnotatedBlock that can then be used for benchmarking.
+
+          Raises:
+            StatusNotOk: When annotating the block fails.
+          )");
 }
 
 }  // namespace gematria

--- a/gematria/datasets/python/bhive_to_exegesis.cc
+++ b/gematria/datasets/python/bhive_to_exegesis.cc
@@ -32,7 +32,7 @@ namespace gematria {
 namespace py = ::pybind11;
 
 PYBIND11_MODULE(bhive_to_exegesis, m) {
-  m.doc() = "Code for annotating baisc blocks.";
+  m.doc() = "Code for annotating basic blocks.";
 
   py::google::ImportStatusModule();
 
@@ -45,19 +45,36 @@ PYBIND11_MODULE(bhive_to_exegesis, m) {
   py::class_<AnnotatedBlock>(m, "AnnotatedBlock");
 
   py::class_<BHiveToExegesis>(m, "BHiveToExegesis")
-      .def("create",
-           [](LlvmArchitectureSupport& ArchitectureSupport) {
-             LLVMInitializeX86Target();
-             LLVMInitializeX86TargetInfo();
-             LLVMInitializeX86TargetMC();
-             LLVMInitializeX86AsmPrinter();
-             LLVMInitializeX86AsmParser();
-             LLVMInitializeX86Disassembler();
-             InitializeX86ExegesisTarget();
+      .def_static(
+          "create",
+          [](LlvmArchitectureSupport& ArchitectureSupport) {
+            LLVMInitializeX86Target();
+            LLVMInitializeX86TargetInfo();
+            LLVMInitializeX86TargetMC();
+            LLVMInitializeX86AsmPrinter();
+            LLVMInitializeX86AsmParser();
+            LLVMInitializeX86Disassembler();
+            InitializeX86ExegesisTarget();
 
-             return LlvmExpectedToStatusOr(
-                 BHiveToExegesis::create(ArchitectureSupport));
-           })
+            return LlvmExpectedToStatusOr(
+                BHiveToExegesis::create(ArchitectureSupport));
+          },
+          py::arg("architecture_support"),
+          R"(Creates a BHiveToExegesis Instance.
+
+          Performs the relevant LLVM setup and creates a BHiveToExegesis
+          instance that can then be used to annotate basic blocks.
+
+          Args:
+            architecture_support: An LLVMArchitectureSupport instance
+              containing the relevant helper classes.
+           
+          Returns:
+            A BHiveToExegsis Instance.
+          
+          Raises:
+            StatusNotOk: When creating the BHiveToExegesis instance fails.
+          )")
       .def(
           "annotate_basic_block",
           [](BHiveToExegesis& Self, std::string BasicBlockHex,

--- a/gematria/datasets/python/bhive_to_exegesis_test.py
+++ b/gematria/datasets/python/bhive_to_exegesis_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from absl.testing import absltest
+from pybind11_abseil import status
+
 from gematria.datasets.python import bhive_to_exegesis
 from gematria.llvm.python import llvm_architecture_support
 
@@ -35,6 +37,12 @@ class BHiveToExegesisTests(absltest.TestCase):
     )
 
     self.assertIsInstance(block_annotations, bhive_to_exegesis.AnnotatedBlock)
+
+  def test_invalid_block(self):
+    with self.assertRaises(status.StatusNotOk):
+      _ = self.bhive_to_exegesis.annotate_basic_block(
+          "INVALID_HEX", bhive_to_exegesis.AnnotatorType.fast, 50
+      )
 
 
 if __name__ == "__main__":

--- a/gematria/datasets/python/bhive_to_exegesis_test.py
+++ b/gematria/datasets/python/bhive_to_exegesis_test.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from gematria.datasets.python import bhive_to_exegesis
+from gematria.llvm.python import llvm_architecture_support
+
+
+class BHiveToExegesisTests(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+
+    self._x86_llvm = llvm_architecture_support.LlvmArchitectureSupport.x86_64()
+    self.bhive_to_exegesis = bhive_to_exegesis.BHiveToExegesis.create(
+        self._x86_llvm
+    )
+
+  def test_bhive_to_exegesis(self):
+    block_annotations = self.bhive_to_exegesis.annotate_basic_block(
+        "4829d38b44246c8b54246848c1fb034829d04839c3",
+        bhive_to_exegesis.AnnotatorType.fast,
+        50,
+    )
+
+    self.assertIsInstance(block_annotations, bhive_to_exegesis.AnnotatedBlock)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
This patch adds python bindings for the bhive_to_exegesis library. This enables us to get annotated basic blocks from raw hex values. Future patches will refactor exegesis_benchmark into a library and add additional functions that will take in the AnnotatedBlock class so that we can then get throughput information.