### PR TITLE
Refactor exegesis_benchmark functionality into a library

### DIFF
--- a/gematria/datasets/BUILD.bazel
+++ b/gematria/datasets/BUILD.bazel
@@ -89,17 +89,28 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "exegesis_benchmark_lib",
+    srcs = ["exegesis_benchmark_lib.cc"],
+    hdrs = ["exegesis_benchmark_lib.h"],
+    deps = [
+        "//gematria/llvm:disassembler",
+        "//gematria/utils:string",
+        "@llvm-project//llvm:Exegesis",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:X86Disassembler",
+    ],
+)
+
 cc_binary(
     name = "exegesis_benchmark",
     srcs = ["exegesis_benchmark.cc"],
     deps = [
-        "//gematria/llvm:disassembler",
-        "//gematria/utils:string",
+        ":exegesis_benchmark_lib",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@llvm-project//llvm:Exegesis",
         "@llvm-project//llvm:Support",
-        "@llvm-project//llvm:X86Disassembler",
     ],
 )
 

--- a/gematria/datasets/exegesis_benchmark.cc
+++ b/gematria/datasets/exegesis_benchmark.cc
@@ -14,18 +14,13 @@
 
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
-#include "gematria/llvm/disassembler.h"
-#include "gematria/utils/string.h"
+#include "gematria/datasets/exegesis_benchmark_lib.h"
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCInst.h"
@@ -39,13 +34,8 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/tools/llvm-exegesis/lib/BenchmarkCode.h"
 #include "llvm/tools/llvm-exegesis/lib/BenchmarkResult.h"
-#include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
-#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
 #include "llvm/tools/llvm-exegesis/lib/PerfHelper.h"
-#include "llvm/tools/llvm-exegesis/lib/RegisterValue.h"
 #include "llvm/tools/llvm-exegesis/lib/ResultAggregator.h"
-#include "llvm/tools/llvm-exegesis/lib/SnippetRepetitor.h"
-#include "llvm/tools/llvm-exegesis/lib/Target.h"
 #include "llvm/tools/llvm-exegesis/lib/TargetSelect.h"
 
 using namespace llvm;
@@ -55,218 +45,6 @@ static cl::opt<std::string> AnnotatedBlocksJson(
     "annotated-blocks-json",
     cl::desc("Filename of the JSON file containing annotated basic blocks"),
     cl::init(""));
-
-Expected<BenchmarkCode> parseJSONBlock(
-    const json::Object &BasicBlockJSON, MCInstPrinter &MachinePrinter,
-    const MCDisassembler &MachineDisassembler, const LLVMState &State,
-    size_t BlockIndex) {
-  BenchmarkCode BenchCode;
-
-  std::optional<StringRef> HexValue = BasicBlockJSON.getString("Hex");
-  if (!HexValue)
-    return llvm::make_error<StringError>(
-        errc::invalid_argument, "Malformed basic block: Basic block at index " +
-                                    Twine(BlockIndex) + " has no hex value");
-
-  std::optional<int64_t> LoopRegister =
-      BasicBlockJSON.getInteger("LoopRegister");
-  if (!LoopRegister.has_value())
-    return llvm::make_error<StringError>(
-        errc::invalid_argument, "Malformed basic block: Basic block at index " +
-                                    Twine(BlockIndex) +
-                                    " has no loop register");
-
-  BenchCode.Key.LoopRegister = *LoopRegister;
-
-  // TODO(ondrasej): Update this after converting gematria::ParseHexString to
-  // return llvm::Expected rather than an optional.
-  std::optional<std::vector<uint8_t>> BytesOr =
-      gematria::ParseHexString(HexValue->str());
-
-  if (!BytesOr.has_value())
-    return llvm::make_error<StringError>(
-        errc::invalid_argument, "Malformed basic block: Basic block at index " +
-                                    Twine(BlockIndex) +
-                                    " has an invalid hex value: " + *HexValue);
-
-  Expected<std::vector<gematria::DisassembledInstruction>>
-      DisInstructionsOrErr = gematria::DisassembleAllInstructions(
-          MachineDisassembler, State.getInstrInfo(), State.getRegInfo(),
-          State.getSubtargetInfo(), MachinePrinter, 0, *BytesOr);
-
-  if (!DisInstructionsOrErr) return DisInstructionsOrErr.takeError();
-
-  std::vector<MCInst> Instructions;
-  Instructions.reserve(DisInstructionsOrErr->size());
-
-  for (const auto &DisInstruction : *DisInstructionsOrErr)
-    Instructions.push_back(DisInstruction.mc_inst);
-
-  BenchCode.Key.Instructions = std::move(Instructions);
-
-  const json::Array *RegisterDefinitions =
-      BasicBlockJSON.getArray("RegisterDefinitions");
-
-  Twine BasicBlockAtIndex = "Basic block at index " + Twine(BlockIndex);
-
-  if (!RegisterDefinitions)
-    return llvm::make_error<StringError>(
-        errc::invalid_argument, "Malformed basic block: " + BasicBlockAtIndex +
-                                    " has no register definitions array");
-
-  for (size_t RegisterLoopIndex = 0;
-       RegisterLoopIndex < RegisterDefinitions->size(); ++RegisterLoopIndex) {
-    const json::Object *RegisterDefinitionObject =
-        (*RegisterDefinitions)[RegisterLoopIndex].getAsObject();
-
-    RegisterValue RegVal;
-    std::optional<int64_t> RegisterIndex =
-        RegisterDefinitionObject->getInteger("Register");
-    std::optional<int64_t> RegisterValue =
-        RegisterDefinitionObject->getInteger("Value");
-    if (!RegisterIndex.has_value() || !RegisterValue.has_value())
-      return llvm::make_error<StringError>(
-          errc::invalid_argument,
-          "Malformed register definition: " + BasicBlockAtIndex +
-              " is missing a register number or value for register at index " +
-              Twine(RegisterLoopIndex));
-
-    RegVal.Register = *RegisterIndex;
-    RegVal.Value = APInt(64, *RegisterValue);
-    BenchCode.Key.RegisterInitialValues.push_back(RegVal);
-  }
-
-  const json::Array *MemoryDefinitions =
-      BasicBlockJSON.getArray("MemoryDefinitions");
-
-  if (!MemoryDefinitions)
-    return llvm::make_error<StringError>(
-        errc::invalid_argument, "Malformed basic block: " + BasicBlockAtIndex +
-                                    " has no memory definitions array");
-
-  size_t MemoryDefinitionIndex = 0;
-
-  for (const auto &MemoryDefinitionValue : *MemoryDefinitions) {
-    const json::Object *MemoryDefinitionObject =
-        MemoryDefinitionValue.getAsObject();
-
-    if (!MemoryDefinitionObject)
-      return llvm::make_error<StringError>(
-          errc::invalid_argument,
-          "Malformed memory definition: " + BasicBlockAtIndex +
-              " has a memory definition at index " +
-              Twine(MemoryDefinitionIndex) + " that is not a JSON object");
-
-    std::optional<StringRef> MemoryDefinitionName =
-        MemoryDefinitionObject->getString("Name");
-    std::optional<int64_t> MemoryDefinitionSize =
-        MemoryDefinitionObject->getInteger("Size");
-
-    std::optional<int64_t> MemoryDefinitionHexValue =
-        MemoryDefinitionObject->getInteger("Value");
-
-    if (!MemoryDefinitionName.has_value() ||
-        !MemoryDefinitionSize.has_value() ||
-        !MemoryDefinitionHexValue.has_value())
-      return llvm::make_error<StringError>(
-          errc::invalid_argument,
-          "Malformed memory definition: " + BasicBlockAtIndex +
-              " has a memory definition at index " +
-              Twine(MemoryDefinitionIndex) + " with no size, name, or value");
-
-    MemoryValue MemVal;
-    MemVal.Value = APInt(32, *MemoryDefinitionHexValue);
-    MemVal.Index = MemoryDefinitionIndex;
-    MemVal.SizeBytes = *MemoryDefinitionSize;
-
-    BenchCode.Key.MemoryValues[MemoryDefinitionName->str()] = MemVal;
-
-    ++MemoryDefinitionIndex;
-  }
-
-  const json::Array *MemoryMappings = BasicBlockJSON.getArray("MemoryMappings");
-
-  if (!MemoryMappings)
-    return llvm::make_error<StringError>(
-        errc::invalid_argument, "Malformed basic block: " + BasicBlockAtIndex +
-                                    " has no memory mappings array");
-
-  for (size_t I = 0; I < MemoryMappings->size(); ++I) {
-    const json::Object *MemoryMappingObject =
-        MemoryMappings->data()[I].getAsObject();
-
-    if (!MemoryMappingObject)
-      return llvm::make_error<StringError>(
-          errc::invalid_argument,
-          "Malformed memory mapping: " + BasicBlockAtIndex +
-              " has a memory mapping at index " + Twine(I) +
-              " which is not a JSON object");
-
-    std::optional<StringRef> MemoryMappingDefinitionName =
-        MemoryMappingObject->getString("Value");
-    std::optional<uintptr_t> MemoryMappingAddress =
-        MemoryMappingObject->getInteger("Address");
-
-    if (!MemoryMappingDefinitionName.has_value() ||
-        !MemoryMappingAddress.has_value())
-      return llvm::make_error<StringError>(
-          errc::invalid_argument,
-          "Malformed memory mapping: " + BasicBlockAtIndex +
-              " has a memory mapping at index " + Twine(I) +
-              " with no name or address");
-
-    MemoryMapping MemMap;
-    MemMap.Address = *MemoryMappingAddress;
-    MemMap.MemoryValueName = MemoryMappingDefinitionName->str();
-    BenchCode.Key.MemoryMappings.push_back(MemMap);
-  }
-
-  return BenchCode;
-}
-
-Expected<double> benchmarkBasicBlock(const BenchmarkCode &BenchCode,
-                                     const BenchmarkRunner &BenchRunner,
-                                     const LLVMState &State) {
-  std::unique_ptr<const SnippetRepetitor> SnipRepetitor =
-      SnippetRepetitor::Create(Benchmark::RepetitionModeE::MiddleHalfLoop,
-                               State, BenchCode.Key.LoopRegister);
-
-  SmallVector<Benchmark, 2> AllResults;
-
-  auto RC1 =
-      BenchRunner.getRunnableConfiguration(BenchCode, 5000, 0, *SnipRepetitor);
-  if (!RC1) return RC1.takeError();
-  auto RC2 =
-      BenchRunner.getRunnableConfiguration(BenchCode, 10000, 0, *SnipRepetitor);
-  if (!RC2) return RC2.takeError();
-
-  std::pair<Error, Benchmark> BenchmarkResultAOrErr =
-      BenchRunner.runConfiguration(std::move(*RC1), {});
-
-  if (std::get<0>(BenchmarkResultAOrErr))
-    return std::move(std::get<0>(BenchmarkResultAOrErr));
-
-  AllResults.push_back(std::move(std::get<1>(BenchmarkResultAOrErr)));
-
-  std::pair<Error, Benchmark> BenchmarkResultBOrErr =
-      BenchRunner.runConfiguration(std::move(*RC2), {});
-
-  if (std::get<0>(BenchmarkResultBOrErr))
-    return std::move(std::get<0>(BenchmarkResultBOrErr));
-
-  AllResults.push_back(std::move(std::get<1>(BenchmarkResultBOrErr)));
-
-  std::unique_ptr<ResultAggregator> ResultAgg =
-      ResultAggregator::CreateAggregator(
-          Benchmark::RepetitionModeE::MiddleHalfLoop);
-
-  Benchmark Result = std::move(AllResults[0]);
-
-  ResultAgg->AggregateResults(Result,
-                              ArrayRef<Benchmark>(AllResults).drop_front());
-
-  return Result.Measurements[0].PerSnippetValue;
-}
 
 ExitOnError ExitOnErr("exegesis-benchmark error: ");
 
@@ -307,35 +85,12 @@ int main(int Argc, char *Argv[]) {
   // Exegesis Setup
   InitializeX86ExegesisTarget();
 
+  std::unique_ptr<gematria::ExegesisBenchmark> Benchmark =
+      ExitOnErr(gematria::ExegesisBenchmark::create());
+
   if (pfm::pfmInitialize())
     ExitOnErr(llvm::make_error<StringError>(inconvertibleErrorCode(),
                                             "Failed to initialize libpfm"));
-
-  const LLVMState State = ExitOnErr(LLVMState::Create("", "native"));
-
-  // More LLVM Setup
-  std::unique_ptr<MCContext> MachineContext = std::make_unique<MCContext>(
-      State.getTargetMachine().getTargetTriple(),
-      State.getTargetMachine().getMCAsmInfo(), &State.getRegInfo(),
-      &State.getSubtargetInfo());
-
-  std::unique_ptr<MCDisassembler> MachineDisassembler(
-      State.getTargetMachine().getTarget().createMCDisassembler(
-          State.getSubtargetInfo(), *MachineContext));
-
-  std::unique_ptr<MCInstPrinter> MachinePrinter(
-      State.getTargetMachine().getTarget().createMCInstPrinter(
-          State.getTargetMachine().getTargetTriple(), 0,
-          *State.getTargetMachine().getMCAsmInfo(), State.getInstrInfo(),
-          State.getRegInfo()));
-
-  // TODO(boomanaiden154): Check the values of the validation counters to
-  // ensure that the benchmarking runs are being run with the assumed
-  // conditions.
-  const std::unique_ptr<BenchmarkRunner> Runner =
-      ExitOnErr(State.getExegesisTarget().createBenchmarkRunner(
-          Benchmark::Latency, State, BenchmarkPhaseSelectorE::Measure,
-          BenchmarkRunner::ExecutionModeE::SubProcess, 30, {}, Benchmark::Min));
 
   auto JsonMemoryBuffer = ExitOnErr(
       errorOrToExpected(MemoryBuffer::getFile(AnnotatedBlocksJson, true)));
@@ -355,15 +110,10 @@ int main(int Argc, char *Argv[]) {
 
     BenchmarkCode BenchCode = exitOnFileError(
         AnnotatedBlocksJson,
-        parseJSONBlock(*AnnotatedBlockObject, *MachinePrinter,
-                       *MachineDisassembler, State, BlockIndex));
-
-    std::unique_ptr<const SnippetRepetitor> SnipRepetitor =
-        SnippetRepetitor::Create(Benchmark::RepetitionModeE::MiddleHalfLoop,
-                                 State, BenchCode.Key.LoopRegister);
+        Benchmark->parseJSONBlock(*AnnotatedBlockObject, BlockIndex));
 
     double Throughput = exitOnFileError(
-        AnnotatedBlocksJson, benchmarkBasicBlock(BenchCode, *Runner, State));
+        AnnotatedBlocksJson, Benchmark->benchmarkBasicBlock(BenchCode));
 
     std::optional<StringRef> HexValue = AnnotatedBlockObject->getString("Hex");
     // The block has already been parsed previously, and thus should have thrown

--- a/gematria/datasets/exegesis_benchmark_lib.cc
+++ b/gematria/datasets/exegesis_benchmark_lib.cc
@@ -1,0 +1,306 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gematria/datasets/exegesis_benchmark_lib.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "gematria/llvm/disassembler.h"
+#include "gematria/utils/string.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkCode.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkResult.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
+#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
+#include "llvm/tools/llvm-exegesis/lib/RegisterValue.h"
+#include "llvm/tools/llvm-exegesis/lib/ResultAggregator.h"
+#include "llvm/tools/llvm-exegesis/lib/SnippetRepetitor.h"
+#include "llvm/tools/llvm-exegesis/lib/Target.h"
+
+using namespace llvm;
+using namespace llvm::exegesis;
+
+namespace gematria {
+
+ExegesisBenchmark::ExegesisBenchmark(LLVMState &&State)
+    : ExegesisState(std::move(State)) {
+  LLVMMCContext = std::make_unique<MCContext>(
+      ExegesisState.getTargetMachine().getTargetTriple(),
+      ExegesisState.getTargetMachine().getMCAsmInfo(),
+      &ExegesisState.getRegInfo(), &ExegesisState.getSubtargetInfo());
+
+  LLVMMCDisassembler = std::unique_ptr<MCDisassembler>(
+      ExegesisState.getTargetMachine().getTarget().createMCDisassembler(
+          ExegesisState.getSubtargetInfo(), *LLVMMCContext));
+
+  LLVMMCInstPrinter = std::unique_ptr<MCInstPrinter>(
+      ExegesisState.getTargetMachine().getTarget().createMCInstPrinter(
+          ExegesisState.getTargetMachine().getTargetTriple(),
+          llvm::InlineAsm::AD_ATT,
+          *ExegesisState.getTargetMachine().getMCAsmInfo(),
+          *ExegesisState.getTargetMachine().getMCInstrInfo(),
+          ExegesisState.getRegInfo()));
+}
+
+Expected<std::unique_ptr<ExegesisBenchmark>> ExegesisBenchmark::create() {
+  Expected<LLVMState> StateOrErr = LLVMState::Create("", "native");
+
+  if (!StateOrErr) return StateOrErr.takeError();
+
+  std::unique_ptr<ExegesisBenchmark> benchmark_instance(
+      new ExegesisBenchmark(std::move(*StateOrErr)));
+
+  // TODO(boomanaiden154): Check the values of the validation counters to
+  // ensure that the benchmarking runs are being run with the assumed
+  // conditions.
+  Expected<std::unique_ptr<BenchmarkRunner>> RunnerOrErr =
+      benchmark_instance->ExegesisState.getExegesisTarget()
+          .createBenchmarkRunner(Benchmark::Latency,
+                                 benchmark_instance->ExegesisState,
+                                 BenchmarkPhaseSelectorE::Measure,
+                                 BenchmarkRunner::ExecutionModeE::SubProcess,
+                                 30, {}, Benchmark::Min);
+
+  if (!RunnerOrErr) return RunnerOrErr.takeError();
+
+  benchmark_instance->BenchRunner = std::move(*RunnerOrErr);
+
+  return benchmark_instance;
+}
+
+Expected<BenchmarkCode> ExegesisBenchmark::parseJSONBlock(
+    const json::Object &BasicBlockJSON, size_t BlockIndex) {
+  BenchmarkCode BenchCode;
+
+  std::optional<StringRef> HexValue = BasicBlockJSON.getString("Hex");
+  if (!HexValue)
+    return llvm::make_error<StringError>(
+        errc::invalid_argument, "Malformed basic block: Basic block at index " +
+                                    Twine(BlockIndex) + " has no hex value");
+
+  std::optional<int64_t> LoopRegister =
+      BasicBlockJSON.getInteger("LoopRegister");
+  if (!LoopRegister.has_value())
+    return llvm::make_error<StringError>(
+        errc::invalid_argument, "Malformed basic block: Basic block at index " +
+                                    Twine(BlockIndex) +
+                                    " has no loop register");
+
+  BenchCode.Key.LoopRegister = *LoopRegister;
+
+  // TODO(ondrasej): Update this after converting gematria::ParseHexString to
+  // return llvm::Expected rather than an optional.
+  std::optional<std::vector<uint8_t>> BytesOr = ParseHexString(HexValue->str());
+
+  if (!BytesOr.has_value())
+    return llvm::make_error<StringError>(
+        errc::invalid_argument, "Malformed basic block: Basic block at index " +
+                                    Twine(BlockIndex) +
+                                    " has an invalid hex value: " + *HexValue);
+
+  Expected<std::vector<DisassembledInstruction>> DisInstructionsOrErr =
+      DisassembleAllInstructions(
+          *LLVMMCDisassembler, ExegesisState.getInstrInfo(),
+          ExegesisState.getRegInfo(), ExegesisState.getSubtargetInfo(),
+          *LLVMMCInstPrinter, 0, *BytesOr);
+
+  if (!DisInstructionsOrErr) return DisInstructionsOrErr.takeError();
+
+  std::vector<MCInst> Instructions;
+  Instructions.reserve(DisInstructionsOrErr->size());
+
+  for (const auto &DisInstruction : *DisInstructionsOrErr)
+    Instructions.push_back(DisInstruction.mc_inst);
+
+  BenchCode.Key.Instructions = std::move(Instructions);
+
+  const json::Array *RegisterDefinitions =
+      BasicBlockJSON.getArray("RegisterDefinitions");
+
+  Twine BasicBlockAtIndex = "Basic block at index " + Twine(BlockIndex);
+
+  if (!RegisterDefinitions)
+    return llvm::make_error<StringError>(
+        errc::invalid_argument, "Malformed basic block: " + BasicBlockAtIndex +
+                                    " has no register definitions array");
+
+  for (size_t RegisterLoopIndex = 0;
+       RegisterLoopIndex < RegisterDefinitions->size(); ++RegisterLoopIndex) {
+    const json::Object *RegisterDefinitionObject =
+        (*RegisterDefinitions)[RegisterLoopIndex].getAsObject();
+
+    RegisterValue RegVal;
+    std::optional<int64_t> RegisterIndex =
+        RegisterDefinitionObject->getInteger("Register");
+    std::optional<int64_t> RegisterValue =
+        RegisterDefinitionObject->getInteger("Value");
+    if (!RegisterIndex.has_value() || !RegisterValue.has_value())
+      return llvm::make_error<StringError>(
+          errc::invalid_argument,
+          "Malformed register definition: " + BasicBlockAtIndex +
+              " is missing a register number or value for register at index " +
+              Twine(RegisterLoopIndex));
+
+    RegVal.Register = *RegisterIndex;
+    RegVal.Value = APInt(64, *RegisterValue);
+    BenchCode.Key.RegisterInitialValues.push_back(RegVal);
+  }
+
+  const json::Array *MemoryDefinitions =
+      BasicBlockJSON.getArray("MemoryDefinitions");
+
+  if (!MemoryDefinitions)
+    return llvm::make_error<StringError>(
+        errc::invalid_argument, "Malformed basic block: " + BasicBlockAtIndex +
+                                    " has no memory definitions array");
+
+  size_t MemoryDefinitionIndex = 0;
+
+  for (const auto &MemoryDefinitionValue : *MemoryDefinitions) {
+    const json::Object *MemoryDefinitionObject =
+        MemoryDefinitionValue.getAsObject();
+
+    if (!MemoryDefinitionObject)
+      return llvm::make_error<StringError>(
+          errc::invalid_argument,
+          "Malformed memory definition: " + BasicBlockAtIndex +
+              " has a memory definition at index " +
+              Twine(MemoryDefinitionIndex) + " that is not a JSON object");
+
+    std::optional<StringRef> MemoryDefinitionName =
+        MemoryDefinitionObject->getString("Name");
+    std::optional<int64_t> MemoryDefinitionSize =
+        MemoryDefinitionObject->getInteger("Size");
+
+    std::optional<int64_t> MemoryDefinitionHexValue =
+        MemoryDefinitionObject->getInteger("Value");
+
+    if (!MemoryDefinitionName.has_value() ||
+        !MemoryDefinitionSize.has_value() ||
+        !MemoryDefinitionHexValue.has_value())
+      return llvm::make_error<StringError>(
+          errc::invalid_argument,
+          "Malformed memory definition: " + BasicBlockAtIndex +
+              " has a memory definition at index " +
+              Twine(MemoryDefinitionIndex) + " with no size, name, or value");
+
+    MemoryValue MemVal;
+    MemVal.Value = APInt(32, *MemoryDefinitionHexValue);
+    MemVal.Index = MemoryDefinitionIndex;
+    MemVal.SizeBytes = *MemoryDefinitionSize;
+
+    BenchCode.Key.MemoryValues[MemoryDefinitionName->str()] = MemVal;
+
+    ++MemoryDefinitionIndex;
+  }
+
+  const json::Array *MemoryMappings = BasicBlockJSON.getArray("MemoryMappings");
+
+  if (!MemoryMappings)
+    return llvm::make_error<StringError>(
+        errc::invalid_argument, "Malformed basic block: " + BasicBlockAtIndex +
+                                    " has no memory mappings array");
+
+  for (size_t I = 0; I < MemoryMappings->size(); ++I) {
+    const json::Object *MemoryMappingObject =
+        MemoryMappings->data()[I].getAsObject();
+
+    if (!MemoryMappingObject)
+      return llvm::make_error<StringError>(
+          errc::invalid_argument,
+          "Malformed memory mapping: " + BasicBlockAtIndex +
+              " has a memory mapping at index " + Twine(I) +
+              " which is not a JSON object");
+
+    std::optional<StringRef> MemoryMappingDefinitionName =
+        MemoryMappingObject->getString("Value");
+    std::optional<uintptr_t> MemoryMappingAddress =
+        MemoryMappingObject->getInteger("Address");
+
+    if (!MemoryMappingDefinitionName.has_value() ||
+        !MemoryMappingAddress.has_value())
+      return llvm::make_error<StringError>(
+          errc::invalid_argument,
+          "Malformed memory mapping: " + BasicBlockAtIndex +
+              " has a memory mapping at index " + Twine(I) +
+              " with no name or address");
+
+    MemoryMapping MemMap;
+    MemMap.Address = *MemoryMappingAddress;
+    MemMap.MemoryValueName = MemoryMappingDefinitionName->str();
+    BenchCode.Key.MemoryMappings.push_back(MemMap);
+  }
+
+  return BenchCode;
+}
+
+Expected<double> ExegesisBenchmark::benchmarkBasicBlock(
+    const BenchmarkCode &BenchCode) {
+  std::unique_ptr<const SnippetRepetitor> SnipRepetitor =
+      SnippetRepetitor::Create(Benchmark::RepetitionModeE::MiddleHalfLoop,
+                               ExegesisState, BenchCode.Key.LoopRegister);
+  SmallVector<Benchmark, 2> AllResults;
+
+  auto RC1 =
+      BenchRunner->getRunnableConfiguration(BenchCode, 5000, 0, *SnipRepetitor);
+  if (!RC1) return RC1.takeError();
+  auto RC2 = BenchRunner->getRunnableConfiguration(BenchCode, 10000, 0,
+                                                   *SnipRepetitor);
+  if (!RC2) return RC2.takeError();
+
+  std::pair<Error, Benchmark> BenchmarkResultAOrErr =
+      BenchRunner->runConfiguration(std::move(*RC1), {});
+
+  if (std::get<0>(BenchmarkResultAOrErr))
+    return std::move(std::get<0>(BenchmarkResultAOrErr));
+
+  AllResults.push_back(std::move(std::get<1>(BenchmarkResultAOrErr)));
+
+  std::pair<Error, Benchmark> BenchmarkResultBOrErr =
+      BenchRunner->runConfiguration(std::move(*RC2), {});
+
+  if (std::get<0>(BenchmarkResultBOrErr))
+    return std::move(std::get<0>(BenchmarkResultBOrErr));
+
+  AllResults.push_back(std::move(std::get<1>(BenchmarkResultBOrErr)));
+
+  std::unique_ptr<ResultAggregator> ResultAgg =
+      ResultAggregator::CreateAggregator(
+          Benchmark::RepetitionModeE::MiddleHalfLoop);
+
+  Benchmark Result = std::move(AllResults[0]);
+
+  ResultAgg->AggregateResults(Result,
+                              ArrayRef<Benchmark>(AllResults).drop_front());
+
+  return Result.Measurements[0].PerSnippetValue;
+}
+
+}  // namespace gematria

--- a/gematria/datasets/exegesis_benchmark_lib.h
+++ b/gematria/datasets/exegesis_benchmark_lib.h
@@ -1,0 +1,56 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <memory>
+
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCDisassembler/MCDisassembler.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkCode.h"
+#include "llvm/tools/llvm-exegesis/lib/BenchmarkRunner.h"
+#include "llvm/tools/llvm-exegesis/lib/LlvmState.h"
+
+namespace gematria {
+
+// ExegesisBenchmark is used for generating benchmark configurations for
+// benchmarks and executing those benchmarks to get real-world data that
+// can then be used for training Gematria models.
+class ExegesisBenchmark {
+ private:
+  explicit ExegesisBenchmark(llvm::exegesis::LLVMState &&State);
+
+ public:
+  static llvm::Expected<std::unique_ptr<ExegesisBenchmark>> create();
+
+  llvm::Expected<llvm::exegesis::BenchmarkCode> parseJSONBlock(
+      const llvm::json::Object &BasicBlockJSON, size_t BlockIndex);
+
+  llvm::Expected<double> benchmarkBasicBlock(
+      const llvm::exegesis::BenchmarkCode &BenchCode);
+
+ private:
+  std::unique_ptr<llvm::MCContext> LLVMMCContext;
+  std::unique_ptr<llvm::MCDisassembler> LLVMMCDisassembler;
+  std::unique_ptr<llvm::MCInstPrinter> LLVMMCInstPrinter;
+
+  std::unique_ptr<llvm::exegesis::BenchmarkRunner> BenchRunner;
+
+  llvm::exegesis::LLVMState ExegesisState;
+};
+
+}  // namespace gematria


### PR DESCRIPTION
This patch refactors the majority of the functionality in the exegesis_benchmark binary into a library. This allows reuse in other parts of the code base, particularly beam pipelines once python bindings have been written.