### PR TITLE
Add intptr_t static cast to silence compiler warning

### DIFF
--- a/gematria/datasets/exegesis_benchmark_lib.cc
+++ b/gematria/datasets/exegesis_benchmark_lib.cc
@@ -313,7 +313,10 @@ Expected<BenchmarkCode> ExegesisBenchmark::processAnnotatedBlock(
       Annotations.accessed_blocks.size());
 
   for (const uintptr_t AccessedBlock : Annotations.accessed_blocks) {
-    MemoryMapping MemMap = {.Address = AccessedBlock, .MemoryValueName = "MEM"};
+    // TODO(boomanaiden154): We should remove this static cast once
+    // upstream llvm-exegesis has transitioned to using uintptr_t.
+    MemoryMapping MemMap = {.Address = static_cast<intptr_t>(AccessedBlock),
+                            .MemoryValueName = "MEM"};
 
     BenchmarkConfiguration.Key.MemoryMappings.push_back(std::move(MemMap));
   }


### PR DESCRIPTION
There is a compiler warning marked as -Werror inside google3 that fires on this code due to Gematria using uintptr_t but llvm-exegesis using intptr_t. For now, static cast this so that we can do an import.