### PR TITLE
Add docstring for get_bbs

### DIFF
--- a/gematria/datasets/pipelines/compile_modules_lib.py
+++ b/gematria/datasets/pipelines/compile_modules_lib.py
@@ -112,11 +112,11 @@ def get_bbs(
   """Creates a pipeline to process BBs from IR modules.
 
   This function returns a function that builds a beam pipeline to automatically
-  load ir files from a ComPile style parquet file, process them into assembly
+  load IR files from a ComPile style Parquet file, process them into assembly
   basic blocks, deduplicate them, and then write them to a text file.
 
   Args:
-    input_file_pattern: A grep-like pattern to use to search for the parquet
+    input_file_pattern: A grep-like pattern to use to search for the Parquet
       files to process.
     output_file: The output file pattern to use when writing the basic blocks
       to disk.

--- a/gematria/datasets/pipelines/compile_modules_lib.py
+++ b/gematria/datasets/pipelines/compile_modules_lib.py
@@ -109,6 +109,22 @@ class DeduplicateBBs(beam.ptransform.PTransform):
 def get_bbs(
     input_file_pattern: str, output_file: str
 ) -> Callable[[beam.Pipeline], None]:
+  """Creates a pipeline to process BBs from IR modules.
+  
+  This function returns a function that builds a beam pipeline to automatically
+  load ir files from a ComPile style parquet file, process them into assembly
+  basic blocks, deduplicate them, and then write them to a text file.
+
+  Args:
+    input_file_pattern: A grep-like pattern to use to search for the parquet
+      files to process.
+    output_file: The output file pattern to use when writing the basic blocks
+      to disk.
+
+  Returns:
+    A function that accepts a beam pipeline and adds on all the steps needed
+    to process the input IR modules.  
+  """
   def pipeline(root: beam.Pipeline) -> None:
     parquet_data = root | 'Read' >> beam.io.ReadFromParquet(
         input_file_pattern, columns=['content']

--- a/gematria/datasets/pipelines/compile_modules_lib.py
+++ b/gematria/datasets/pipelines/compile_modules_lib.py
@@ -110,7 +110,7 @@ def get_bbs(
     input_file_pattern: str, output_file: str
 ) -> Callable[[beam.Pipeline], None]:
   """Creates a pipeline to process BBs from IR modules.
-  
+
   This function returns a function that builds a beam pipeline to automatically
   load ir files from a ComPile style parquet file, process them into assembly
   basic blocks, deduplicate them, and then write them to a text file.
@@ -123,8 +123,9 @@ def get_bbs(
 
   Returns:
     A function that accepts a beam pipeline and adds on all the steps needed
-    to process the input IR modules.  
+    to process the input IR modules.
   """
+
   def pipeline(root: beam.Pipeline) -> None:
     parquet_data = root | 'Read' >> beam.io.ReadFromParquet(
         input_file_pattern, columns=['content']


### PR DESCRIPTION
This patch adds a docstring for get_bbs. This function is long enough that having a docstring is probably useful. The internal linting tools also complain about a lack of a docstring.