### PR TITLE
Add remove memory accessing instructions flag to compile_modules binary

### DIFF
--- a/gematria/datasets/pipelines/compile_modules.py
+++ b/gematria/datasets/pipelines/compile_modules.py
@@ -32,6 +32,12 @@ _OUTPUT_TXT_FILE = flags.DEFINE_string(
     'output_txt_file', None, 'The path to the output txt file', required=True
 )
 
+_REMOVE_MEMORY_ACCESSING_INSTRUCTIONS = flags.DEFINE_bool(
+    'remove_memory_accessing_instructions',
+    False,
+    'Whether to remove memory accessing instructions from the basic blocks.',
+)
+
 
 def main(argv) -> None:
   del argv  # Unused.
@@ -39,7 +45,9 @@ def main(argv) -> None:
   beam_options = pipeline_options.PipelineOptions()
 
   pipeline_constructor = compile_modules_lib.get_bbs(
-      os.path.join(_PARQUET_FOLDER.value, '*.parquet'), _OUTPUT_TXT_FILE.value
+      os.path.join(_PARQUET_FOLDER.value, '*.parquet'),
+      _OUTPUT_TXT_FILE.value,
+      _REMOVE_MEMORY_ACCESSING_INSTRUCTIONS.value,
   )
 
   with beam.Pipeline(options=beam_options) as pipeline:


### PR DESCRIPTION
This patch adds a remove memory accessing instructions flag to the compile_modules binary. This is necessary now that the get_bbs function requires this parameter.