### PR TITLE
Minor cleanup in datasets

### DIFF
--- a/gematria/datasets/annotating_importer.h
+++ b/gematria/datasets/annotating_importer.h
@@ -20,16 +20,20 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "gematria/datasets/bhive_importer.h"
 #include "gematria/llvm/canonicalizer.h"
 #include "gematria/llvm/disassembler.h"
+#include "gematria/proto/throughput.pb.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ELFTypes.h"
+#include "quipper/perf_data.pb.h"
 #include "quipper/perf_parser.h"
 #include "quipper/perf_reader.h"
 

--- a/gematria/datasets/annotating_importer_test.cc
+++ b/gematria/datasets/annotating_importer_test.cc
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
 #include "gematria/llvm/canonicalizer.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/proto/throughput.pb.h"
@@ -45,7 +44,7 @@ class AnnotatingImporterTest : public ::testing::Test {
   static constexpr std::string_view kPerfDataFilepath =
       "com_google_gematria/gematria/testing/testdata/"
       "simple_x86_elf_object.perf.data";
-  static constexpr absl::string_view kSourceName = "test: skl";
+  static constexpr std::string_view kSourceName = "test: skl";
 
   std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles_;
 

--- a/gematria/datasets/annotating_importer_test.cc
+++ b/gematria/datasets/annotating_importer_test.cc
@@ -14,11 +14,14 @@
 
 #include "gematria/datasets/annotating_importer.h"
 
+#include <cassert>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "gematria/llvm/canonicalizer.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gematria/proto/throughput.pb.h"
@@ -29,8 +32,6 @@
 
 namespace gematria {
 namespace {
-
-using ::testing::ElementsAre;
 
 // TODO(virajbshah): Consider adding a test that builds a binary from source,
 // runs a `perf record` on it, and then runs `GetAnnotatedBasicBlockProtos`

--- a/gematria/datasets/bhive_importer.h
+++ b/gematria/datasets/bhive_importer.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "gematria/llvm/canonicalizer.h"
@@ -52,7 +53,9 @@ class BHiveImporter {
       llvm::ArrayRef<DisassembledInstruction> disassembled_instructions,
       uint64_t base_address = 0);
 
-  //
+  // Converts machine code in the form of an array of bytes into gematria
+  // DisassembledInstructions that can more easily be used by downstream
+  // tooling.
   absl::StatusOr<std::vector<DisassembledInstruction> >
   DisassembledInstructionsFromMachineCode(llvm::ArrayRef<uint8_t> machine_code,
                                           uint64_t base_address = 0);


### PR DESCRIPTION
This patch does some minor cleanup in gematria/datasets such as removing unused includes, adding includes where necessary to be IWYU compliant, and adding docstrings where necessary.

This based off of feedback from the 9-4-24 import.