### PR TITLE
Cleanup includes in gematria/llvm

### DIFF
--- a/gematria/llvm/asm_parser.cc
+++ b/gematria/llvm/asm_parser.cc
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/gematria/llvm/asm_parser_test.cc
+++ b/gematria/llvm/asm_parser_test.cc
@@ -14,10 +14,8 @@
 
 #include "gematria/llvm/asm_parser.h"
 
-#include <cstdint>
 #include <memory>
-#include <tuple>
-#include <type_traits>
+#include <string_view>
 
 #include "absl/status/status.h"
 #include "gematria/llvm/llvm_architecture_support.h"
@@ -25,10 +23,8 @@
 #include "gematria/testing/matchers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "lib/Target/X86/MCTargetDesc/X86BaseInfo.h"  //// IWYU pragma: keep (for opcodes).
 #include "lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/IR/InlineAsm.h"
-#include "llvm/MC/MCInst.h"
 
 namespace gematria {
 namespace {
@@ -41,10 +37,6 @@ class AsmParserTest : public testing::Test {
 
   std::unique_ptr<LlvmArchitectureSupport> llvm_x86_;
 };
-
-auto HasOpcode(int opcode) {
-  return testing::Property(&llvm::MCInst::getOpcode, opcode);
-}
 
 TEST_F(AsmParserTest, IntelAssembly) {
   static constexpr std::string_view kAssembly = R"asm(

--- a/gematria/llvm/canonicalizer.cc
+++ b/gematria/llvm/canonicalizer.cc
@@ -14,20 +14,29 @@
 
 #include "gematria/llvm/canonicalizer.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "gematria/basic_block/basic_block.h"
 #include "lib/Target/X86/MCTargetDesc/X86BaseInfo.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/bit.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
 
 namespace gematria {

--- a/gematria/llvm/canonicalizer_test.cc
+++ b/gematria/llvm/canonicalizer_test.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "gematria/basic_block/basic_block.h"
 #include "gematria/llvm/asm_parser.h"
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gmock/gmock.h"

--- a/gematria/llvm/diagnostics_test.cc
+++ b/gematria/llvm/diagnostics_test.cc
@@ -15,6 +15,7 @@
 #include "gematria/llvm/diagnostics.h"
 
 #include <memory>
+#include <string_view>
 
 #include "gematria/llvm/llvm_architecture_support.h"
 #include "gmock/gmock.h"

--- a/gematria/llvm/disassembler_test.cc
+++ b/gematria/llvm/disassembler_test.cc
@@ -15,7 +15,6 @@
 #include "gematria/llvm/disassembler.h"
 
 #include <cstdint>
-#include <iterator>
 #include <memory>
 
 #include "absl/status/status.h"
@@ -34,7 +33,6 @@
 namespace gematria {
 namespace {
 
-using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;

--- a/gematria/llvm/llvm_architecture_support_test.cc
+++ b/gematria/llvm/llvm_architecture_support_test.cc
@@ -15,6 +15,7 @@
 #include "gematria/llvm/llvm_architecture_support.h"
 
 #include <memory>
+#include <utility>
 
 #include "absl/status/status.h"
 #include "gematria/llvm/llvm_to_absl.h"

--- a/gematria/llvm/python/llvm_architecture_support.cc
+++ b/gematria/llvm/python/llvm_architecture_support.cc
@@ -14,13 +14,16 @@
 
 #include "gematria/llvm/llvm_architecture_support.h"
 
+#include <string>
+#include <string_view>
+
 #include "gematria/llvm/llvm_to_absl.h"
+#include "pybind11/cast.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-#include "pybind11/stl_bind.h"
+#include "pybind11/stl.h"  // IWYU pragma: keep
 #include "pybind11_abseil/import_status_module.h"
-#include "pybind11_abseil/status_casters.h"
+#include "pybind11_abseil/status_casters.h"  // IWYU pragma: keep
 
 namespace gematria {
 
@@ -38,7 +41,7 @@ PYBIND11_MODULE(llvm_architecture_support, m) {
       This class does not have any public methods or attributes in Python. It is
       only meant to be used as a token passed to Gematria C++ classes and
       functions that use LLVM APIs and expect LLVM objects as their inputs.)")
-      .def_static(  //
+      .def_static(
           "from_triple",
           [](std::string_view llvm_triple, std::string_view cpu,
              std::string_view cpu_features) {


### PR DESCRIPTION
This patch cleans up extra/missing includes in gematria/llvm to make it IWYU compliant (at least according to clangd). Some other misc cleanup like deleting dead functions was also performed.