### PR TITLE
Fix loading of annotated blocks for tests.

### DIFF
--- a/gematria/testing/python/BUILD.bazel
+++ b/gematria/testing/python/BUILD.bazel
@@ -8,7 +8,10 @@ gematria_py_library(
     name = "basic_blocks_with_throughput",
     testonly = True,
     srcs = ["basic_blocks_with_throughput.py"],
-    data = ["//gematria/testing/testdata:basic_blocks_with_throughput.pbtxt"],
+    data = [
+        "//gematria/testing/testdata:annotated_basic_blocks_with_throughput.pbtxt",
+        "//gematria/testing/testdata:basic_blocks_with_throughput.pbtxt",
+    ],
     visibility = ["//:internal_users"],
     deps = [
         "//gematria/basic_block/python:basic_block",

--- a/gematria/testing/python/basic_blocks_with_throughput.py
+++ b/gematria/testing/python/basic_blocks_with_throughput.py
@@ -36,8 +36,11 @@ _ANNOTATED_BASIC_BLOCK_RESOURCE_PATH = os.path.join(
     _ROOT_PATH,
     'gematria/testing/testdata/annotated_basic_blocks_with_throughput.pbtxt',
 )
-# Parsed basic block. An exception is thrown if the basic blocks do not parse.
+# Parsed basic blocks. An exception is thrown if the basic blocks do not parse.
 _BASIC_BLOCKS: throughput_pb2.BasicBlockWithThroughputListProto | None = None
+_ANNOTATED_BASIC_BLOCKS: throughput_pb2.BasicBlockWithThroughputListProto | None = (
+    None
+)
 
 CleanupFn = Callable[
     [throughput_pb2.BasicBlockWithThroughputProto],
@@ -48,23 +51,35 @@ KeepFn = Callable[[throughput_pb2.BasicBlockWithThroughputProto], bool]
 
 def _get_basic_block_list_proto(get_annotated_blocks=False):
   """Loads basic blocks from test data."""
-  global _BASIC_BLOCKS
-  if _BASIC_BLOCKS is None:
-    runfiles_dir = os.environ.get('PYTHON_RUNFILES')
-    runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
-    assert runfiles_env is not None
-    with open(
-        runfiles_env.Rlocation(
-            _ANNOTATED_BASIC_BLOCK_RESOURCE_PATH
-            if get_annotated_blocks
-            else _BASIC_BLOCK_RESOURCE_PATH
-        ),
-        'rt',
-    ) as f:
-      _BASIC_BLOCKS = text_format.Parse(
-          f.read(), throughput_pb2.BasicBlockWithThroughputListProto()
-      )
-  return _BASIC_BLOCKS
+  global _BASIC_BLOCKS, _ANNOTATED_BASIC_BLOCKS
+  if get_annotated_blocks:
+    if _ANNOTATED_BASIC_BLOCKS is None:
+      runfiles_dir = os.environ.get('PYTHON_RUNFILES')
+      runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
+      assert runfiles_env is not None
+      with open(
+          runfiles_env.Rlocation(_ANNOTATED_BASIC_BLOCK_RESOURCE_PATH),
+          'rt',
+      ) as f:
+        _ANNOTATED_BASIC_BLOCKS = text_format.Parse(
+            f.read(), throughput_pb2.BasicBlockWithThroughputListProto()
+        )
+    assert _ANNOTATED_BASIC_BLOCKS is not None
+    return _ANNOTATED_BASIC_BLOCKS
+  else:  # get_annotated_blocks == False
+    if _BASIC_BLOCKS is None:
+      runfiles_dir = os.environ.get('PYTHON_RUNFILES')
+      runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
+      assert runfiles_env is not None
+      with open(
+          runfiles_env.Rlocation(_BASIC_BLOCK_RESOURCE_PATH),
+          'rt',
+      ) as f:
+        _BASIC_BLOCKS = text_format.Parse(
+            f.read(), throughput_pb2.BasicBlockWithThroughputListProto()
+        )
+    assert _BASIC_BLOCKS is not None
+    return _BASIC_BLOCKS
 
 
 def get_basic_blocks(

--- a/gematria/testing/python/basic_blocks_with_throughput.py
+++ b/gematria/testing/python/basic_blocks_with_throughput.py
@@ -52,9 +52,9 @@ KeepFn = Callable[[throughput_pb2.BasicBlockWithThroughputProto], bool]
 def _get_basic_block_list_proto(get_annotated_blocks=False):
   """Loads basic blocks from test data."""
   global _BASIC_BLOCKS, _ANNOTATED_BASIC_BLOCKS
-  
+
   runfiles_dir = os.environ.get('PYTHON_RUNFILES')
-  runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})  
+  runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
   if get_annotated_blocks:
     if _ANNOTATED_BASIC_BLOCKS is None:
       assert runfiles_env is not None

--- a/gematria/testing/python/basic_blocks_with_throughput.py
+++ b/gematria/testing/python/basic_blocks_with_throughput.py
@@ -52,10 +52,11 @@ KeepFn = Callable[[throughput_pb2.BasicBlockWithThroughputProto], bool]
 def _get_basic_block_list_proto(get_annotated_blocks=False):
   """Loads basic blocks from test data."""
   global _BASIC_BLOCKS, _ANNOTATED_BASIC_BLOCKS
+  
+  runfiles_dir = os.environ.get('PYTHON_RUNFILES')
+  runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})  
   if get_annotated_blocks:
     if _ANNOTATED_BASIC_BLOCKS is None:
-      runfiles_dir = os.environ.get('PYTHON_RUNFILES')
-      runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
       assert runfiles_env is not None
       with open(
           runfiles_env.Rlocation(_ANNOTATED_BASIC_BLOCK_RESOURCE_PATH),
@@ -68,8 +69,6 @@ def _get_basic_block_list_proto(get_annotated_blocks=False):
     return _ANNOTATED_BASIC_BLOCKS
   else:  # get_annotated_blocks == False
     if _BASIC_BLOCKS is None:
-      runfiles_dir = os.environ.get('PYTHON_RUNFILES')
-      runfiles_env = runfiles.Create({'RUNFILES_DIR': runfiles_dir})
       assert runfiles_env is not None
       with open(
           runfiles_env.Rlocation(_BASIC_BLOCK_RESOURCE_PATH),

--- a/gematria/testing/python/basic_blocks_with_throughput_test.py
+++ b/gematria/testing/python/basic_blocks_with_throughput_test.py
@@ -55,6 +55,22 @@ class BasicBlocksWithThroughputTest(absltest.TestCase):
 
     self.assertLen(blocks, num_blocks)
 
+  def test_get_annotated_blocks(self):
+    """Checks that annotated blocks are returned when requested."""
+    num_blocks = 3
+    blocks = basic_blocks_with_throughput.get_basic_blocks(
+        num_blocks, get_annotated_blocks=True
+    )
+
+    self.assertLen(blocks, num_blocks)
+    has_annotations = False
+    for block in blocks:
+      for instruction in block.basic_block.canonicalized_instructions:
+        if len(instruction.instruction_annotations):
+          has_annotations = True
+          break
+    self.assertTrue(has_annotations)
+
   def test_cleanup(self):
     num_blocks = 10
 

--- a/gematria/testing/testdata/annotated_basic_blocks_with_throughput.pbtxt
+++ b/gematria/testing/testdata/annotated_basic_blocks_with_throughput.pbtxt
@@ -35,7 +35,7 @@ basic_blocks {
   }
   inverse_throughputs {
     source: "test: predicted value for tests"
-    inverse_throughput_cycles: [1.0, 
+    inverse_throughput_cycles: [1.0]
     prefix_inverse_throughputs {
       inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     }
@@ -160,7 +160,7 @@ basic_blocks {
   }
   inverse_throughputs {
     source: "test: predicted value for tests"
-    inverse_throughput_cycles: [3.0, 
+    inverse_throughput_cycles: [3.0]
   }
 }
 basic_blocks {
@@ -553,7 +553,7 @@ basic_blocks {
   }
   inverse_throughputs {
     source: "test: predicted value for tests"
-    inverse_throughput_cycles: [5.0, 
+    inverse_throughput_cycles: [5.0]
   }
 }
 basic_blocks {
@@ -2879,6 +2879,46 @@ basic_blocks {
       inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     }
     prefix_inverse_throughputs {
+      inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    }
+  }
+}
+basic_blocks {
+  basic_block: {
+    canonicalized_instructions {
+      mnemonic: "MOV32ri"
+      prefixes: "REP"
+      llvm_mnemonic: "MOV32ri"
+      output_operands {
+        register_name: "EAX"
+      }
+      input_operands {
+        immediate_value: 1
+      }
+      instruction_annotations {
+        name: "made_up_cache_miss_freq"
+        value: 0.96679023420394
+      }
+    }
+  }
+  inverse_throughputs: {
+    source: "llvm_sim: triple=x86_64-linux-gnu, cpu=haswell, cpu_features="
+    inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    prefix_inverse_throughputs: {
+      inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    }
+  }
+  inverse_throughputs: {
+    source: "test: made up values"
+    inverse_throughput_cycles: [5.0, 4.0, 3.0, 2.0, 1.0]
+    prefix_inverse_throughputs: {
+      inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    }
+  }
+  inverse_throughputs: {
+    source: "test: predicted value for tests"
+    inverse_throughput_cycles: [1.0]
+    prefix_inverse_throughputs: {
       inverse_throughput_cycles: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     }
   }


### PR DESCRIPTION
 * Fixes incorrect logic for loading of annotated basic blocks for testing in `basic_blocks_with_throughput.py`.
 * Previously, we would silently load un-annotated blocks.