### PR TITLE
Fix tuple capitalization in benchmark_bbs_lib

### DIFF
--- a/gematria/datasets/pipelines/benchmark_bbs_lib.py
+++ b/gematria/datasets/pipelines/benchmark_bbs_lib.py
@@ -47,7 +47,7 @@ class FormatBBsForOutput(beam.DoFn):
   """A Beam function for formatting hex/throughput values for output."""
 
   def process(
-      self, block_hex_and_throughput: Tuple[str, float]
+      self, block_hex_and_throughput: tuple[str, float]
   ) -> Iterable[str]:
     block_hex, throughput = block_hex_and_throughput
     yield f'{block_hex},{throughput}'


### PR DESCRIPTION
This patch fixes capitalization of tuple in benchmark_bbs_lib. In a patch update, we switched from Tuple to tuple (import from typing to the standard python builtin), but I forgot to update one of the types, which causes build failures locally.

The build failures did not occur in CI due to the test requiring perf counters to pass.