### PR TITLE
Use LLVMState helper for getting register index

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ name: Gematria CI
 # TODO(virajbshah): Find a better way to keep these two in sync without the
 # need to update one manually every time the other is changed.
 env:
-  LLVM_COMMIT: fac87b889c50f493ba332950f613fa15a45be9a9
+  LLVM_COMMIT: 99fe5954d258511ec2e36e8c7f612568e9701ab7
 
 on:
   push:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -201,9 +201,9 @@ new_git_repository(
 # The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
 # `.github/workflows/main.yaml` must be updated to match this everytime it is
 # changed.
-LLVM_COMMIT = "fac87b889c50f493ba332950f613fa15a45be9a9"
+LLVM_COMMIT = "99fe5954d258511ec2e36e8c7f612568e9701ab7"
 
-LLVM_SHA256 = "b840910ce442f8efd332945c6fe467a828381322e1f89c924e017b817af16662"
+LLVM_SHA256 = "878369fb50c6990a92f7a93ad2b988c7c2fe0dbc9022a435a722e8efd899598b"
 
 http_archive(
     name = "llvm-raw",

--- a/gematria/datasets/exegesis_benchmark_lib.cc
+++ b/gematria/datasets/exegesis_benchmark_lib.cc
@@ -384,13 +384,13 @@ Expected<double> ExegesisBenchmark::benchmarkBasicBlock(
 
 Expected<MCRegister> ExegesisBenchmark::getRegisterFromName(
     StringRef RegisterName) {
-  auto RegIterator =
-      ExegesisState.getRegNameToRegNoMapping().find(RegisterName);
-  if (RegIterator == ExegesisState.getRegNameToRegNoMapping().end())
+  std::optional<MCRegister> register_index =
+      ExegesisState.getRegisterNumberFromName(RegisterName);
+  if (!register_index.has_value())
     return llvm::make_error<StringError>(
         errc::invalid_argument,
         "Invalid register name for target: " + RegisterName);
-  return RegIterator->second;
+  return *register_index;
 }
 
 }  // namespace gematria


### PR DESCRIPTION
This patch replaces our direct search of the register name to number mapping to a function now included in LLVMState that handles that for us, leaving us to solely deal with the error handling. Necessary now that the accessor for the register name to number mapping will be deleted soonish.