### PR TITLE
Enable layering_checks for gematria/utils

### DIFF
--- a/gematria/utils/BUILD.bazel
+++ b/gematria/utils/BUILD.bazel
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_library(
@@ -17,6 +18,7 @@ cc_test(
     srcs = ["string_test.cc"],
     deps = [
         ":string",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.