### PR TITLE
Enable layering_checks for gematria/testing

### DIFF
--- a/gematria/testing/BUILD.bazel
+++ b/gematria/testing/BUILD.bazel
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_library(
@@ -21,6 +22,7 @@ cc_test(
     copts = ["-Iexternal/llvm-project/llvm"],
     deps = [
         ":llvm",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@llvm-project//llvm:MC",
         "@llvm-project//llvm:X86UtilsAndDesc",
@@ -50,6 +52,7 @@ cc_test(
     srcs = ["matchers_test.cc"],
     deps = [
         ":matchers",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -72,6 +75,7 @@ cc_test(
     deps = [
         ":parse_proto",
         "//gematria/proto:canonicalized_instruction_cc_proto",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/gematria/testing/python/BUILD.bazel
+++ b/gematria/testing/python/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "gematria_py_library", "gematria_py_test")
 
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 gematria_py_library(

--- a/gematria/testing/testdata/BUILD.bazel
+++ b/gematria/testing/testdata/BUILD.bazel
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 exports_files(


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.