### PR TITLE
Enable layering checks for gematria/sequence

### DIFF
--- a/gematria/sequence/BUILD.bazel
+++ b/gematria/sequence/BUILD.bazel
@@ -1,3 +1,4 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )

--- a/gematria/sequence/python/BUILD.bazel
+++ b/gematria/sequence/python/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "gematria_py_binary", "gematria_py_library", "gematria_py_
 
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 gematria_py_binary(


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.