### PR TITLE
Enable layering checks for gematria/proto

### DIFF
--- a/gematria/proto/BUILD.bazel
+++ b/gematria/proto/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:proto.bzl", "gematria_proto_library")
 
 package(
     default_visibility = ["//:external_users"],
+    features = ["layering_check"],
 )
 
 gematria_proto_library(


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.