### PR TITLE
Enable layering checks for gematria/model

### DIFF
--- a/gematria/model/BUILD.bazel
+++ b/gematria/model/BUILD.bazel
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/gematria/model/python/BUILD.bazel
+++ b/gematria/model/python/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "gematria_py_library", "gematria_py_test", "gematria_pybin
 
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 gematria_py_library(


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.