### PR TITLE
Enable layering checks for gematria/io

### DIFF
--- a/gematria/io/BUILD.bazel
+++ b/gematria/io/BUILD.bazel
@@ -1,3 +1,4 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_checks"],
 )

--- a/gematria/io/python/BUILD.bazel
+++ b/gematria/io/python/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "gematria_py_library", "gematria_py_test")
 
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_checks"],
 )
 
 gematria_py_library(


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.