### PR TITLE
Enable layering checks for gematria/granite

### DIFF
--- a/gematria/granite/BUILD.bazel
+++ b/gematria/granite/BUILD.bazel
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_library(
@@ -25,6 +26,7 @@ cc_test(
         "//gematria/proto:basic_block_cc_proto",
         "//gematria/testing:parse_proto",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/gematria/granite/python/BUILD.bazel
+++ b/gematria/granite/python/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "gematria_py_binary", "gematria_py_library", "gematria_py_
 
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 gematria_py_library(


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.