### PR TITLE
Enable layering checks for gematria/experiments

### DIFF
--- a/gematria/experiments/BUILD.bazel
+++ b/gematria/experiments/BUILD.bazel
@@ -1,3 +1,4 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_checks"],
 )

--- a/gematria/experiments/access_pattern_bm/BUILD.bazel
+++ b/gematria/experiments/access_pattern_bm/BUILD.bazel
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_checks"],
 )
 
 # The macro BALANCE_FLUSHING_TIME is defined when this matches. This enables the


### PR DESCRIPTION
This will more closely match the setup that we have internally and prevent transitive dependency issues.

Fixes part of #200.