### PR TITLE
Bump LLVM version to near ToT

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ name: Gematria CI
 # TODO(virajbshah): Find a better way to keep these two in sync without the
 # need to update one manually every time the other is changed.
 env:
-  LLVM_COMMIT: 99fe5954d258511ec2e36e8c7f612568e9701ab7
+  LLVM_COMMIT: 29b92d07746fac26cd64c914bc9c5c3833974f6d
 
 on:
   push:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -201,9 +201,9 @@ new_git_repository(
 # The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
 # `.github/workflows/main.yaml` must be updated to match this everytime it is
 # changed.
-LLVM_COMMIT = "99fe5954d258511ec2e36e8c7f612568e9701ab7"
+LLVM_COMMIT = "29b92d07746fac26cd64c914bc9c5c3833974f6d"
 
-LLVM_SHA256 = "878369fb50c6990a92f7a93ad2b988c7c2fe0dbc9022a435a722e8efd899598b"
+LLVM_SHA256 = "cf0285831d98a1655f1d580f51c4f43a5bf34c2c59e1b34b61f60fc38a4b6ce6"
 
 http_archive(
     name = "llvm-raw",

--- a/gematria/datasets/exegesis_benchmark_lib.cc
+++ b/gematria/datasets/exegesis_benchmark_lib.cc
@@ -355,7 +355,7 @@ Expected<double> ExegesisBenchmark::benchmarkBasicBlock(
   if (!RC2) return RC2.takeError();
 
   std::pair<Error, Benchmark> BenchmarkResultAOrErr =
-      BenchRunner->runConfiguration(std::move(*RC1), {});
+      BenchRunner->runConfiguration(std::move(*RC1), {}, std::nullopt);
 
   if (std::get<0>(BenchmarkResultAOrErr))
     return std::move(std::get<0>(BenchmarkResultAOrErr));
@@ -363,7 +363,7 @@ Expected<double> ExegesisBenchmark::benchmarkBasicBlock(
   AllResults.push_back(std::move(std::get<1>(BenchmarkResultAOrErr)));
 
   std::pair<Error, Benchmark> BenchmarkResultBOrErr =
-      BenchRunner->runConfiguration(std::move(*RC2), {});
+      BenchRunner->runConfiguration(std::move(*RC2), {}, std::nullopt);
 
   if (std::get<0>(BenchmarkResultBOrErr))
     return std::move(std::get<0>(BenchmarkResultBOrErr));

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -163,7 +163,7 @@ Expected<ExecutionAnnotations> ExegesisAnnotator::findAccessedAddrs(
     BenchmarkRunner::RunnableConfiguration &RC = *RCOrErr;
 
     std::pair<Error, Benchmark> BenchmarkResultOrErr =
-        Runner->runConfiguration(std::move(RC), {});
+        Runner->runConfiguration(std::move(RC), {}, std::nullopt);
 
     // If we don't have any errors executing the snippet, we executed the
     // snippet successfully and thus have all the needed memory annotations.


### PR DESCRIPTION
This includes a new patch for exegesis that enables pinning the benchmarking process to a specific core.