### PR TITLE
Add metrics to benchmarking pipeline

### DIFF
--- a/gematria/datasets/pipelines/benchmark_bbs_lib.py
+++ b/gematria/datasets/pipelines/benchmark_bbs_lib.py
@@ -21,6 +21,8 @@ from pybind11_abseil import status
 from gematria.proto import execution_annotation_pb2
 from gematria.datasets.python import exegesis_benchmark
 
+_BEAM_METRIC_NAMESPACE_NAME = 'benchmark_bbs'
+
 
 class BenchmarkBasicBlock(beam.DoFn):
   """A Beam function that benchmarks basic blocks."""
@@ -28,7 +30,7 @@ class BenchmarkBasicBlock(beam.DoFn):
   def setup(self):
     self._exegesis_benchmark = exegesis_benchmark.ExegesisBenchmark.create()
     self._benchmark_failed_blocks = metrics.Metrics.counter(
-        'benchmark_bbs', 'failed_benchmarking_blocks'
+        _BEAM_METRIC_NAMESPACE_NAME, 'benchmark_blocks_failed'
     )
 
   def process(

--- a/gematria/datasets/pipelines/benchmark_bbs_lib.py
+++ b/gematria/datasets/pipelines/benchmark_bbs_lib.py
@@ -15,6 +15,7 @@
 from collections.abc import Callable, Iterable
 
 import apache_beam as beam
+from apache_beam import metrics
 from pybind11_abseil import status
 
 from gematria.proto import execution_annotation_pb2
@@ -26,6 +27,9 @@ class BenchmarkBasicBlock(beam.DoFn):
 
   def setup(self):
     self._exegesis_benchmark = exegesis_benchmark.ExegesisBenchmark.create()
+    self._benchmark_failed_blocks = metrics.Metrics.counter(
+        'benchmark_bbs', 'failed_benchmarking_blocks'
+    )
 
   def process(
       self,


### PR DESCRIPTION
This patch adds metrics to the benchmarking pipeline, which will be reported by the beam executor to give more insight into what happened during the execution.