### PR TITLE
Minor cleanups for find_accessed_addrs

### DIFF
--- a/gematria/datasets/block_wrapper.S
+++ b/gematria/datasets/block_wrapper.S
@@ -16,17 +16,18 @@
 
 .text
 
-.global gematria_before_block
-.type gematria_before_block, %function
+.global gematria_prologue
+.type gematria_prologue, %function
 // This code is copied directly before the code we execute, as we need exact
 // control over the code that is executed, so we can't do it from C++. Its job
 // is to initialise the registers to consistent values so that the accessed
 // addresses don't depend on the register state when calling FindAccessedAddrs.
 //
-// It takes one argument, in rdi: a pointer to a struct containing the initial
-// register values for this execution.
+// See the "WrappedFunc" typedef for the function signature this code has. Since
+// it doesn't return we make no guarantees about preserving registers / stack
+// frame, but we do use the normal calling convention for input parameters.
 // TODO(orodley): Update to support r16-r31.
-gematria_before_block:
+gematria_prologue:
   mov r15, rdi
   mov rax, [r15 + 0x00]
   mov rbx, [r15 + 0x08]
@@ -45,8 +46,8 @@ gematria_before_block:
   mov r14, [r15 + 0x70]
   mov r15, [r15 + 0x78]
 
-_gematria_before_block_size = . - gematria_before_block
-.size gematria_before_block, _gematria_before_block_size
+_gematria_prologue_size = . - gematria_prologue
+.size gematria_prologue, _gematria_prologue_size
 
 // This code is copied directly after the code we execute, as we no longer have
 // a stack to hold a return address. Its job is just to cleanly exit the process
@@ -55,9 +56,9 @@ _gematria_before_block_size = . - gematria_before_block
 //
 // We do this by raising SIGABRT. We can't call any standard library functions,
 // as we don't have a stack. So we have to issue the syscalls manually.
-.global gematria_after_block
-.type gematria_after_block, %function
-gematria_after_block:
+.global gematria_epilogue
+.type gematria_epilogue, %function
+gematria_epilogue:
   // getpid()
   mov rax, 39
   syscall
@@ -73,16 +74,16 @@ gematria_after_block:
   // random bytes are next.
   ud2
 
-_gematria_after_block_size = . - gematria_after_block
-.size gematria_after_block, _gematria_after_block_size
+_gematria_epilogue_size = . - gematria_epilogue
+.size gematria_epilogue, _gematria_epilogue_size
 
 .rodata
-// Store the size of gematria_before_block, so we know how much to copy.
-.global gematria_after_block_size
-gematria_after_block_size:
-  .quad _gematria_after_block_size
+// Store the size of gematria_prologue, so we know how much to copy.
+.global gematria_prologue_size
+gematria_prologue_size:
+  .quad _gematria_prologue_size
 
 // Ditto for gematria_after_block.
-.global gematria_before_block_size
-gematria_before_block_size:
-  .quad _gematria_before_block_size
+.global gematria_epilogue_size
+gematria_epilogue_size:
+  .quad _gematria_epilogue_size

--- a/gematria/datasets/block_wrapper.h
+++ b/gematria/datasets/block_wrapper.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 
-#include "third_party/absl/types/span.h"
+#include "absl/types/span.h"
 
 extern "C" {
 

--- a/gematria/datasets/block_wrapper.h
+++ b/gematria/datasets/block_wrapper.h
@@ -17,33 +17,42 @@
 
 #include <stdint.h>
 
-#include "absl/types/span.h"
+#include "third_party/absl/types/span.h"
 
 extern "C" {
 
 // This is a function, defined in block_wrapper.S. But we're not going to call
 // it directly, we're going to copy it after the block we're given, and execute
 // the whole thing. So we declare it as a byte array instead.
-extern const uint8_t gematria_before_block;
+extern const uint8_t gematria_prologue;
 
 // Ditto.
-extern const uint8_t gematria_after_block;
+extern const uint8_t gematria_epilogue;
 
 // A separate symbol, also defined in block_wrapper.S, which gives the size of
 // the function.
-extern const uint64_t gematria_before_block_size;
+extern const uint64_t gematria_prologue_size;
 
 // Ditto.
-extern const uint64_t gematria_after_block_size;
+extern const uint64_t gematria_epilogue_size;
 }
 
-inline absl::Span<const uint8_t> GetGematriaBeforeBlockCode() {
-  return absl::MakeConstSpan(&gematria_before_block,
-                             gematria_before_block_size);
+namespace gematria {
+
+inline absl::Span<const uint8_t> GetPrologueCode() {
+  return absl::MakeConstSpan(&gematria_prologue, gematria_prologue_size);
 }
 
-inline absl::Span<const uint8_t> GetGematriaAfterBlockCode() {
-  return absl::MakeConstSpan(&gematria_after_block, gematria_after_block_size);
+inline absl::Span<const uint8_t> GetEpilogueCode() {
+  return absl::MakeConstSpan(&gematria_epilogue, gematria_epilogue_size);
 }
+
+struct RawX64Regs;
+
+// This is the signature for the parameters the prologue code expects. It never
+// returns, and makes no attempt to preserve registers or the stack frame.
+typedef void (*WrappedFunc)(const RawX64Regs *initial_regs);
+
+}  // namespace gematria
 
 #endif  // RESEARCH_DEVTOOLS_EXEGESIS_GEMATRIA_BHIVE_BLOCK_WRAPPER_H_

--- a/gematria/datasets/find_accessed_addrs.h
+++ b/gematria/datasets/find_accessed_addrs.h
@@ -25,7 +25,7 @@
 namespace gematria {
 
 // We need a register struct with each member directly encoded so that it has a
-// predictible memory layout to pass into the prelude assembly which sets the
+// predictable memory layout to pass into the prelude assembly which sets the
 // registers before executing the block
 struct RawX64Regs {
   int64_t rax;


### PR DESCRIPTION
* Rename "before_block" and "after_block" to "prologue" and "epilogue"
* Use a typedef for the function type rather than stating it in the cast
* Fix a typo