### PR TITLE
Switch runfiles usage to python library

### DIFF
--- a/gematria/datasets/python/BUILD.bazel
+++ b/gematria/datasets/python/BUILD.bazel
@@ -94,7 +94,6 @@ gematria_py_test(
         "//gematria/proto:basic_block_py_pb2",
         "//gematria/proto:canonicalized_instruction_py_pb2",
         "//gematria/proto:throughput_py_pb2",
-        "@rules_python//python/runfiles",
     ],
 )
 

--- a/gematria/datasets/python/annotating_importer_test.py
+++ b/gematria/datasets/python/annotating_importer_test.py
@@ -15,13 +15,14 @@
 import os
 
 from absl.testing import absltest
+from runfiles import runfiles
+
 from gematria.datasets.python import annotating_importer
 from gematria.llvm.python import canonicalizer
 from gematria.llvm.python import llvm_architecture_support
 from gematria.proto import basic_block_pb2
 from gematria.proto import canonicalized_instruction_pb2
 from gematria.proto import throughput_pb2
-from rules_python.python.runfiles import runfiles
 
 _CanonicalizedOperandProto = (
     canonicalized_instruction_pb2.CanonicalizedOperandProto


### PR DESCRIPTION
A while back, the canonical way within Gematria to get bazel runfiles was switched to using the runfiles library installed through pypi. This patch makes annotating_importer_test use this as it seems like this was written before the change and did not get updated afterwards.