### PR TITLE
Cleanup extra uses of rules_python

### DIFF
--- a/gematria/llvm/python/BUILD.bazel
+++ b/gematria/llvm/python/BUILD.bazel
@@ -63,7 +63,4 @@ gematria_py_library(
         "@llvm-project//llvm:opt",
     ],
     visibility = ["//:internal_users"],
-    deps = [
-        "@rules_python//python/runfiles",
-    ],
 )


### PR DESCRIPTION
This patch cleans up one final use of rules_python where we do not actually need it. We cannot remove the entire dependency as it includes the bazel rules that we need in order to build the python elements of the project.