### PR TITLE
Use loop register name in annotated bb JSON

### DIFF
--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input.cc
@@ -115,8 +115,6 @@ llvm::json::Value GetJSONForSnippet(
   if (annotated_block.AccessedAddrs.has_loop_register())
     current_snippet["LoopRegister"] =
         annotated_block.AccessedAddrs.loop_register();
-  else
-    current_snippet["LoopRegister"] = llvm::MCRegister::NoRegister;
 
   if (annotated_block.AccessedAddrs.accessed_blocks_size() > 0) {
     llvm::json::Array memory_definitions;

--- a/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/loop_register.test
+++ b/gematria/datasets/convert_bhive_to_llvm_exegesis_input_tests/loop_register.test
@@ -39,11 +39,11 @@
 
 ; RUN: mkdir %t.jsondir
 ; RUN: %convert_bhive_to_llvm_exegesis_input --json_output_dir=%t.jsondir --bhive_csv=%t/test.csv --skip_no_loop_register=false --blocks_per_json_file=1
-; cat %t.jsondir/0.json | FileCheck %s --check-prefix JSON0
-; cat %t.jsondir/1.json | FileCheck %s --check-prefix JSON1
+; RUN: cat %t.jsondir/0.json | FileCheck %s --check-prefix JSON0
+; RUN: cat %t.jsondir/1.json | FileCheck %s --check-prefix JSON1
 
-; JSON0: "LoopRegister": null
-; JSON1: "LoopRegister": 56
+; JSON0-NOT: "LoopRegister"
+; JSON1: "LoopRegister": "RDX"
 
 ; The first line in test.csv contains an assembly snippet that uses every single
 ; GPR (%RAX-%R15), leaving no register available to be used as the loop

--- a/gematria/datasets/exegesis_benchmark_lib_test.cc
+++ b/gematria/datasets/exegesis_benchmark_lib_test.cc
@@ -100,7 +100,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONBlock) {
   StringRef JSONBlock = R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "MemoryDefinitions": [
       {
         "Name": "MEM",
@@ -135,7 +135,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONBlock) {
   EXPECT_THAT(BenchCode->Key.Instructions,
               UnorderedElementsAre(IsMCInst(X86::CMP32rm, _)));
 
-  EXPECT_EQ(BenchCode->Key.LoopRegister, 51);
+  EXPECT_EQ(BenchCode->Key.LoopRegister, X86::RAX);
 
   EXPECT_THAT(BenchCode->Key.MemoryValues,
               UnorderedElementsAre(Pair("MEM", FieldsAre(1, 4096, 0))));
@@ -152,24 +152,11 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONNoHex) {
             "Malformed basic block: Basic block at index 1 has no hex value");
 }
 
-TEST_F(ExegesisBenchmarkTest, TestParseJSONNoLoopRegister) {
-  Expected<std::string> ErrorMessage = getErrorMessage(R"json(
-  {
-    "Hex": ""
-  }
-  )json");
-  ASSERT_TRUE(static_cast<bool>(ErrorMessage));
-
-  EXPECT_EQ(
-      *ErrorMessage,
-      "Malformed basic block: Basic block at index 1 has no loop register");
-}
-
 TEST_F(ExegesisBenchmarkTest, TestParseJSONInvalidHex) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "INVALIDHEX",
-    "LoopRegister": 51
+    "LoopRegister": "RAX"
   }
   )json");
   ASSERT_TRUE(static_cast<bool>(ErrorMessage));
@@ -183,7 +170,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONNoRegisterDefinitions) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51
+    "LoopRegister": "RAX"
   }
   )json");
   ASSERT_TRUE(static_cast<bool>(ErrorMessage));
@@ -197,7 +184,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMissingRegisterIndexValue) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Value": 86016
@@ -216,7 +203,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMissingMemoryDefinitions) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "RCX",
@@ -236,7 +223,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMemoryDefinitionNotObject) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "RCX",
@@ -257,7 +244,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMemoryDefinitionMissingField) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "RCX",
@@ -282,7 +269,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMissingMemoryMappings) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "RCX",
@@ -309,7 +296,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMemoryMappingNonObject) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "RCX",
@@ -337,7 +324,7 @@ TEST_F(ExegesisBenchmarkTest, TestParseJSONMemoryMappingMissingField) {
   Expected<std::string> ErrorMessage = getErrorMessage(R"json(
   {
     "Hex": "3b31",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "RCX",
@@ -369,7 +356,7 @@ TEST_F(ExegesisBenchmarkTest, TestBenchmarkAdd) {
   Expected<double> BenchmarkResult = benchmark(R"json(
   {
     "Hex": "4801c1",
-    "LoopRegister": 51,
+    "LoopRegister": "RAX",
     "RegisterDefinitions": [
       {
         "Register": "HSI",


### PR DESCRIPTION
This patch makes it so that JSON files produced by convert_bhive_to_llvm_exegesis_input use names for the loop registers rather than simply emitting register numbers. This involved modifying the loop register test to actually check that we were emitting loop register names (which we were already doing) and updating the parsing code in exegesis_benchmark_lib to parse loop register names rather than expecting register indices that might change from one LLVM version to the next.