### PR TITLE
Enable running annotations importer test internally

### DIFF
--- a/gematria/datasets/BUILD.bazel
+++ b/gematria/datasets/BUILD.bazel
@@ -90,7 +90,6 @@ cc_test(
         "//gematria/llvm:llvm_architecture_support",
         "//gematria/proto:throughput_cc_proto",
         "//gematria/testing:matchers",
-        "@bazel_tools//tools/cpp/runfiles",
         "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
This patch fixes annotating_importer_test so that it can be run internally as the bazel runfiles rule only kind of exists. We instead just get the value from the TEST_SRCDIR environment variable and then append the object file/perf data file path to it to get the data that we need.