### PR TITLE
Get LLVM Binary paths in setup instead of init

### DIFF
--- a/gematria/datasets/pipelines/compile_modules_lib.py
+++ b/gematria/datasets/pipelines/compile_modules_lib.py
@@ -36,13 +36,15 @@ class OptimizeModules(beam.DoFn):
 
   def __init__(self, optimization_pipelines: Sequence[str]):
     self._optimization_pipelines = optimization_pipelines
-    self._opt_path = gematria.llvm.python.runfiles.get_llvm_binary_path('opt')
     self._modules_succeeded = metrics.Metrics.counter(
         _BEAM_METRIC_NAMESPACE_NAME, 'optimize_modules_success'
     )
     self._modules_failed = metrics.Metrics.counter(
         _BEAM_METRIC_NAMESPACE_NAME, 'optimize_modules_failure'
     )
+
+  def setup(self):
+    self._opt_path = gematria.llvm.python.runfiles.get_llvm_binary_path('opt')
 
   def optimize_module(
       self, input_module: bytes, optimization_pipeline: str
@@ -69,13 +71,15 @@ class LowerModulesAsm(beam.DoFn):
 
   def __init__(self, optimization_levels: Sequence[str]):
     self._optimization_levels = optimization_levels
-    self._llc_path = gematria.llvm.python.runfiles.get_llvm_binary_path('llc')
     self._modules_succeded = metrics.Metrics.counter(
         _BEAM_METRIC_NAMESPACE_NAME, 'lower_modules_success'
     )
     self._modules_failed = metrics.Metrics.counter(
         _BEAM_METRIC_NAMESPACE_NAME, 'lower_modules_failure'
     )
+
+  def setup(self):
+    self._llc_path = gematria.llvm.python.runfiles.get_llvm_binary_path('llc')
 
   def lower_module(self, optimization_level: str, input_module: bytes) -> bytes:
     command_vector = [

--- a/gematria/datasets/pipelines/compile_modules_lib_test.py
+++ b/gematria/datasets/pipelines/compile_modules_lib_test.py
@@ -40,6 +40,7 @@ class CompileModulesTests(absltest.TestCase):
     module_optimizer = compile_modules_lib.OptimizeModules(
         ['default<O0>', 'instcombine']
     )
+    module_optimizer.setup()
     optimized_modules = list(
         module_optimizer.process(ir_utils.get_bc_from_ir(ir_string))
     )
@@ -69,6 +70,7 @@ class CompileModulesTests(absltest.TestCase):
     ir_string_bc = ir_utils.get_bc_from_ir(ir_string)
 
     module_lower_transform = compile_modules_lib.LowerModulesAsm(['-O0', '-O1'])
+    module_lower_transform.setup()
     lowered_modules = list(module_lower_transform.process(ir_string_bc))
 
     self.assertLen(lowered_modules, 2)


### PR DESCRIPTION
This patch moves the code getting the LLVM binary paths to the beam DoFn setup function rather than __init__. This is necessary as some implementations of get_llvm_binary_path require extracting the binary from an archive to a temporary directory on the local machine. Putting this in __init__ does not guarantee that this happens on anything other than the machine running it (one) whereas running it in setup ensures the appropriate setup takes place for each worker instance.