### PR TITLE
Remove `owning_binary_` from `AnnotatingImporter` state.

### DIFF
--- a/gematria/datasets/annotating_importer.cc
+++ b/gematria/datasets/annotating_importer.cc
@@ -357,7 +357,8 @@ absl::StatusOr<std::vector<BasicBlockWithThroughputProto>>
 AnnotatingImporter::GetAnnotatedBasicBlockProtos(
     std::string_view elf_file_name, std::string_view perf_data_file_name,
     std::string_view source_name) {
-  auto owning_binary = LoadBinary(elf_file_name);
+  absl::StatusOr<llvm::object::OwningBinary<llvm::object::Binary>>
+      owning_binary = LoadBinary(elf_file_name);
   if (!owning_binary.ok()) {
     return owning_binary.status();
   }


### PR DESCRIPTION
 * There is no longer any point of keeping `owning_binary_` as part of the `AnnotatingImporter` state, since it is not re-used between calls to `GetAnnotatedBasicBlockProtos`, which is the intended use of `AnnotatingImporter`.
 * This change is meant to help merge some functionality from `annotating_importer` with `extract_bbs_from_obj_lib`.