### PR TITLE
Fix use after move to get exegesis annotator working in pipeline

### DIFF
--- a/gematria/datasets/bhive_to_exegesis.h
+++ b/gematria/datasets/bhive_to_exegesis.h
@@ -49,7 +49,7 @@ class BHiveToExegesis {
 
  private:
   std::unique_ptr<ExegesisAnnotator> LLVMAnnotator;
-  llvm::exegesis::LLVMState ExegesisState;
+  std::unique_ptr<llvm::exegesis::LLVMState> ExegesisState;
   gematria::X86Canonicalizer Canonicalizer;
   gematria::BHiveImporter BHiveImporter;
   LlvmArchitectureSupport &ArchSupport;
@@ -57,7 +57,7 @@ class BHiveToExegesis {
 
   BHiveToExegesis(
       LlvmArchitectureSupport &ArchitectureSupport,
-      llvm::exegesis::LLVMState &&LLVMExegesisState,
+      std::unique_ptr<llvm::exegesis::LLVMState> &&LLVMExegesisState,
       std::unique_ptr<gematria::ExegesisAnnotator> &&LLVMExegesisAnnotator);
 
   absl::StatusOr<ExecutionAnnotations> getAccessedAddrs(

--- a/gematria/datasets/pipelines/BUILD.bazel
+++ b/gematria/datasets/pipelines/BUILD.bazel
@@ -40,6 +40,9 @@ gematria_py_test(
     env = {
         "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",
     },
+    tags = [
+        "perf_counters",
+    ],
     deps = [
         ":compile_modules_lib",
         "//gematria/testing/python:ir_utils",

--- a/gematria/datasets/pipelines/compile_modules.py
+++ b/gematria/datasets/pipelines/compile_modules.py
@@ -47,7 +47,10 @@ _REMOVE_MEMORY_ACCESSING_INSTRUCTIONS = flags.DEFINE_bool(
 )
 
 _ANNOTATOR_TYPE = flags.DEFINE_enum(
-    'annotator_type', 'fast', ['fast'], 'The type of annotator to use.'
+    'annotator_type',
+    'fast',
+    ['fast', 'exegesis'],
+    'The type of annotator to use.',
 )
 
 _MAX_ANNOTATION_ATTEMPTS = flags.DEFINE_integer(
@@ -56,9 +59,10 @@ _MAX_ANNOTATION_ATTEMPTS = flags.DEFINE_integer(
     'The maximum number of times to try annotating a block before giving up',
 )
 
-# TODO(boomanaiden154): Currently, only the fast annotator works. Eventually
-# this should be fixed so we can use the exegesis annotator too.
-ANNOTATOR_MAPPING = {'fast': bhive_to_exegesis.AnnotatorType.fast}
+ANNOTATOR_MAPPING = {
+    'fast': bhive_to_exegesis.AnnotatorType.fast,
+    'exegesis': bhive_to_exegesis.AnnotatorType.exegesis,
+}
 
 
 def main(argv) -> None:


### PR DESCRIPTION
This patch fixes a user after move in BHiveToExegesis/related classes where we would create a LLVMState, pass it into a couple other constructors to create things that would store a reference to LLVMState, and then promptly move it to call the BHiveToExegesis constructor. This resulted in use after moves, which were ultimately caught by ubsan. This patch fixes that behavior by encapsulating LLVMState within a unique_ptr to prevent the problems.

The exegesis annotator is also enabled in the compile_modules invocation script and test coverage is added now that it works.