### PR TITLE
Pass unique_ptr by value in bhive_to_exegesis

### DIFF
--- a/gematria/datasets/bhive_to_exegesis.cc
+++ b/gematria/datasets/bhive_to_exegesis.cc
@@ -47,8 +47,8 @@ namespace gematria {
 
 BHiveToExegesis::BHiveToExegesis(
     LlvmArchitectureSupport& ArchitectureSupport,
-    std::unique_ptr<llvm::exegesis::LLVMState>&& LLVMExegesisState,
-    std::unique_ptr<ExegesisAnnotator>&& LLVMExegesisAnnotator)
+    std::unique_ptr<llvm::exegesis::LLVMState> LLVMExegesisState,
+    std::unique_ptr<ExegesisAnnotator> LLVMExegesisAnnotator)
     : LLVMAnnotator(std::move(LLVMExegesisAnnotator)),
       ExegesisState(std::move(LLVMExegesisState)),
       Canonicalizer(&ArchitectureSupport.target_machine()),

--- a/gematria/datasets/bhive_to_exegesis.h
+++ b/gematria/datasets/bhive_to_exegesis.h
@@ -57,8 +57,8 @@ class BHiveToExegesis {
 
   BHiveToExegesis(
       LlvmArchitectureSupport &ArchitectureSupport,
-      std::unique_ptr<llvm::exegesis::LLVMState> &&LLVMExegesisState,
-      std::unique_ptr<gematria::ExegesisAnnotator> &&LLVMExegesisAnnotator);
+      std::unique_ptr<llvm::exegesis::LLVMState> LLVMExegesisState,
+      std::unique_ptr<gematria::ExegesisAnnotator> LLVMExegesisAnnotator);
 
   absl::StatusOr<ExecutionAnnotations> getAccessedAddrs(
       absl::Span<const uint8_t> BasicBlock,


### PR DESCRIPTION
This patch passes unique_ptrs within bhive_to_exegesis by value rather than by r-value reference.

Suggested in #249.