### PR TITLE
Add support for df register in basic_block_utils

### DIFF
--- a/gematria/datasets/basic_block_utils.cc
+++ b/gematria/datasets/basic_block_utils.cc
@@ -33,6 +33,12 @@ namespace gematria {
 
 unsigned getSuperRegister(unsigned OriginalRegister,
                           const MCRegisterInfo &RegisterInfo) {
+  // Sections of EFLAGS that are explicitly modeled by LLVM as separate
+  // registers should all return eflags.
+  if (OriginalRegister == X86::EFLAGS || OriginalRegister == X86::DF) {
+    return X86::EFLAGS;
+  }
+
   // We should be able to get the super register by getting an iterator from
   // RegisterInfo and getting the back, but this always returns a value of
   // zero.

--- a/gematria/datasets/basic_block_utils_test.cc
+++ b/gematria/datasets/basic_block_utils_test.cc
@@ -189,6 +189,14 @@ TEST_F(BasicBlockUtilsTest, DISABLED_UsedRegistersSingleByteDefines) {
               UnorderedElementsAre(X86::RAX, X86::RDX, X86::RCX));
 }
 
+TEST_F(BasicBlockUtilsTest, MovsqImplicitDfUsesEflags) {
+  std::vector<unsigned> UsedRegisters = getUsedRegs(R"asm(
+    movsq
+  )asm");
+  EXPECT_THAT(UsedRegisters,
+              UnorderedElementsAre(X86::RSI, X86::RDI, X86::EFLAGS));
+}
+
 TEST_F(BasicBlockUtilsTest, UnusedGPRegisterSingleInstruction) {
   std::optional<unsigned> UnusedGPRegister = getUnusedGPReg(R"asm(
     mov %rax, %rcx


### PR DESCRIPTION
Certain instructions implicitly use the df register, which means we need to support it for the exegesis annotator so that we do not get MC verification errors. Additionally, it is good to explicitly define the state to ensure we have deterministic execution. This patch adds support for the df register by explicitly returning eflags as the super register as LLVM does not seem to explicitly model df as a subregister of eflags.

Part of a fix for #251.