### PR TITLE
Add benchmark success blocks counter to benchmarking pipeline

### DIFF
--- a/gematria/datasets/pipelines/benchmark_bbs_lib.py
+++ b/gematria/datasets/pipelines/benchmark_bbs_lib.py
@@ -29,6 +29,9 @@ class BenchmarkBasicBlock(beam.DoFn):
 
   def setup(self):
     self._exegesis_benchmark = exegesis_benchmark.ExegesisBenchmark.create()
+    self._benchmark_success_blocks = metrics.Metrics.counter(
+        _BEAM_METRIC_NAMESPACE_NAME, 'benchmark_bbs_success'
+    )
     self._benchmark_failed_blocks = metrics.Metrics.counter(
         _BEAM_METRIC_NAMESPACE_NAME, 'benchmark_blocks_failed'
     )
@@ -44,8 +47,10 @@ class BenchmarkBasicBlock(beam.DoFn):
       benchmark_value = self._exegesis_benchmark.benchmark_basic_block(
           benchmark_code
       )
+      self._benchmark_success_blocks.inc()
       yield (block_with_annotations.block_hex, benchmark_value)
     except status.StatusNotOk:
+      self._benchmark_failed_blocks.inc()
       pass
 
 


### PR DESCRIPTION
This patch adds a counter to track the number of blocks that have succeeded. This is quite a useful metric to look at on the status page for the Beam executor to track how fast things are progressing and how far along things are.

Also actually increment the failed blocks counter because apparently I forgot to do that in the last patch.