### PR TITLE
Add option to skip blocks with no loop register during annotation

### DIFF
--- a/gematria/datasets/pipelines/compile_modules.py
+++ b/gematria/datasets/pipelines/compile_modules.py
@@ -64,6 +64,13 @@ _MAX_ANNOTATION_ATTEMPTS = flags.DEFINE_integer(
     'The maximum number of times to try annotating a block before giving up',
 )
 
+_SKIP_NO_LOOP_REGISTER = flags.DEFINE_bool(
+    'skip_no_loop_register',
+    False,
+    'Whether or not to skip emitting basic blocks for which a loop register'
+    ' cannot be found.',
+)
+
 
 def main(argv) -> None:
   del argv  # Unused.
@@ -77,6 +84,7 @@ def main(argv) -> None:
       ANNOTATOR_MAPPING[_ANNOTATOR_TYPE.value],
       _MAX_ANNOTATION_ATTEMPTS.value,
       _OUTPUT_VOCAB_FILE.value,
+      _SKIP_NO_LOOP_REGISTER.value,
   )
 
   with beam.Pipeline(options=beam_options) as pipeline:

--- a/gematria/datasets/pipelines/compile_modules_lib_test.py
+++ b/gematria/datasets/pipelines/compile_modules_lib_test.py
@@ -94,7 +94,7 @@ class CompileModulesTests(parameterized.TestCase):
       bhive_to_exegesis.AnnotatorType.exegesis,
   ])
   def test_annotate_bbs(self, annotator_type):
-    annotator = compile_modules_lib.AnnotateBBs(annotator_type, 50)
+    annotator = compile_modules_lib.AnnotateBBs(annotator_type, 50, False)
     annotator.setup()
 
     annotated_blocks = list(
@@ -102,6 +102,18 @@ class CompileModulesTests(parameterized.TestCase):
     )
 
     self.assertLen(annotated_blocks, 1)
+
+  def test_annotate_bbs_no_loop_register(self):
+    annotator = compile_modules_lib.AnnotateBBs(
+        bhive_to_exegesis.AnnotatorType.fast, 50, True
+    )
+    annotator.setup()
+
+    annotated_blocks = list(
+        annotator.process('4889C84889DA4889FE4889EC4D89C84D89DA4D89EC4D89FE')
+    )
+
+    self.assertLen(annotated_blocks, 0)
 
   def test_get_vocab(self):
     get_vocab_function = compile_modules_lib.GetVocab()
@@ -185,6 +197,7 @@ class CompileModulesTests(parameterized.TestCase):
         annotator_type,
         50,
         vocab_output_file_pattern,
+        False,
     )
 
     with test_pipeline.TestPipeline() as pipeline_under_test:


### PR DESCRIPTION
This patch adds an option to the compile_modules pipeline to skip emitting blocks that do not have any loop register attached to them because they use all the GPRs. This is necessary when we want to benchmark in loop mode.

This is intended to fix an issue where when running the benchmarking pipeline (which is currently setup to only run in loop mode), we just pass MCRegister::NoRegister, which causes a machine code verification error as that is not valid. I will open another patch to fix that at some point.