### PR TITLE
Explicitly define df register

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -199,9 +199,9 @@ new_git_repository(
 # The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
 # `.github/workflows/main.yaml` must be updated to match this everytime it is
 # changed.
-LLVM_COMMIT = "29b92d07746fac26cd64c914bc9c5c3833974f6d"
+LLVM_COMMIT = "842fd1537521d38913aec5c9a081afedf97d88fe"
 
-LLVM_SHA256 = "cf0285831d98a1655f1d580f51c4f43a5bf34c2c59e1b34b61f60fc38a4b6ce6"
+LLVM_SHA256 = "21a1d434b4dbbafee65c2a9fc8e64ac3e3210eab9c5d67affd8d6d36bbf979b3"
 
 http_archive(
     name = "llvm-raw",

--- a/gematria/datasets/basic_block_utils.cc
+++ b/gematria/datasets/basic_block_utils.cc
@@ -33,12 +33,6 @@ namespace gematria {
 
 unsigned getSuperRegister(unsigned OriginalRegister,
                           const MCRegisterInfo &RegisterInfo) {
-  // Sections of EFLAGS that are explicitly modeled by LLVM as separate
-  // registers should all return eflags.
-  if (OriginalRegister == X86::EFLAGS || OriginalRegister == X86::DF) {
-    return X86::EFLAGS;
-  }
-
   // We should be able to get the super register by getting an iterator from
   // RegisterInfo and getting the back, but this always returns a value of
   // zero.

--- a/gematria/datasets/basic_block_utils_test.cc
+++ b/gematria/datasets/basic_block_utils_test.cc
@@ -193,8 +193,7 @@ TEST_F(BasicBlockUtilsTest, MovsqImplicitDfUsesEflags) {
   std::vector<unsigned> UsedRegisters = getUsedRegs(R"asm(
     movsq
   )asm");
-  EXPECT_THAT(UsedRegisters,
-              UnorderedElementsAre(X86::RSI, X86::RDI, X86::EFLAGS));
+  EXPECT_THAT(UsedRegisters, UnorderedElementsAre(X86::RSI, X86::RDI, X86::DF));
 }
 
 TEST_F(BasicBlockUtilsTest, UnusedGPRegisterSingleInstruction) {

--- a/gematria/datasets/find_accessed_addrs_exegesis.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis.cc
@@ -179,7 +179,7 @@ Expected<ExecutionAnnotations> ExegesisAnnotator::findAccessedAddrs(
       RegVal.Value = APInt(32, kInitialRegVal);
       NewRegisterValue->set_register_value(kInitialRegVal);
     } else if (RegisterIndex == X86::EFLAGS || RegisterIndex == X86::MXCSR ||
-               RegisterIndex == X86::FPCW) {
+               RegisterIndex == X86::FPCW || RegisterIndex == X86::DF) {
       RegVal.Value = APInt(32, 0);
       NewRegisterValue->set_register_value(0);
     } else if (MRI.getRegClass(X86::RFP32RegClassID).contains(RegisterIndex)) {

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -174,6 +174,9 @@ TEST_F(FindAccessedAddrsExegesisTest, DFRegister) {
     movsq
   )asm");
   ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
+  EXPECT_THAT(AddrsOrErr->initial_registers(),
+              Contains(Property("register_name",
+                                &RegisterAndValue::register_name, "DF")));
 }
 
 // Test that we can annotate snippets using various different register


### PR DESCRIPTION
Now that llvm-exegesis has support for explicitly setting the df register, we should explicitly define df rather than eflags/rflags when something in the block uses df. This fixes a MC verification error when using the loop snippet repetitor due to implicitly defined registers not being set as live-ins.