### PR TITLE
Fix incorrect instruction mnemonic in exegesis annotator test

### DIFF
--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -278,13 +278,13 @@ TEST_F(FindAccessedAddrsExegesisTest, STRegister) {
 TEST_F(FindAccessedAddrsExegesisTest, AVX512XMMYMMRegisters) {
   // This test requires AVX512, skip if we are not running on a CPU with
   // AVX512F.
-  if (!__builtin_cpu_supports("avx512f")) {
-    GTEST_SKIP() << "CPU does not support AVX512, skipping.";
+  if (!__builtin_cpu_supports("avx512vl")) {
+    GTEST_SKIP() << "CPU does not support AVX512VL, skipping.";
   }
 
   auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
-    vmovdqu %xmm16, (%rax)
-    vmovdqu %ymm16, (%rax)
+    vmovdqu32 %xmm16, (%rax)
+    vmovdqu32 %ymm16, (%rax)
   )asm");
   ASSERT_TRUE(static_cast<bool>(AddrsOrErr));
   EXPECT_THAT(


### PR DESCRIPTION
vmovdqu does not work with the 128-bit/256-bit AVX512 registers. Switch the instruction so that the test actually works on system with AVX512VL support. This was causing test failures on system with AVX512. I did not catch this originally as I was testing on znver2.