### PR TITLE
Update comment in exegesis_benchmark_lib.h

### DIFF
--- a/gematria/datasets/exegesis_benchmark_lib.h
+++ b/gematria/datasets/exegesis_benchmark_lib.h
@@ -49,9 +49,8 @@ class ExegesisBenchmark {
       const llvm::exegesis::BenchmarkCode &BenchCode);
 
  private:
-  // TODO(boomanaiden154): This is duplicated with code from Exegesis for
-  // snippet file parsing. That code should be moved to LLVMState so that we
-  // can reuse it here.
+  // This is a simple wrapper around functionality in ExegesisState that maps
+  // optional values to a register or an error.
   llvm::Expected<llvm::MCRegister> getRegisterFromName(
       llvm::StringRef RegisterName);
 


### PR DESCRIPTION
This patch updates the comment on getRegisterFromName in exegesis_benchmark_lib.h to get rid of the TODO as that was addressed in \#209. Also add some additional context about why the function exists.