### PR TITLE
Bump the CMake LLVM CI commit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ name: Gematria CI
 # TODO(virajbshah): Find a better way to keep these two in sync without the
 # need to update one manually every time the other is changed.
 env:
-  LLVM_COMMIT: 29b92d07746fac26cd64c914bc9c5c3833974f6d
+  LLVM_COMMIT: cd66c9b6a04689659348c0a3ff4c1205b1133fe9
 
 on:
   push:


### PR DESCRIPTION
This patch bumps the LLVM commit used by the CI system for the CMake build. This should be kept in sync with what is used for the bazel build, which is something I have forgotten to do for the past couple LLVM commit bumps.