### PR TITLE
Bump clang-format version to v19

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,9 +48,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check c++ formatting
-      uses: jidicula/clang-format-action@v4.11.0
+      uses: jidicula/clang-format-action@v4.14.0
       with:
-        clang-format-version: '18'
+        clang-format-version: '19'
         check-path: 'src'
   check-bazel-formatting:
     name: Bazel Formatting Check

--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -221,7 +221,7 @@ std::ostream& operator<<(std::ostream& os, const InstructionOperand& operand);
 // Represents an annotation holding a value such as some measure/statistic
 // paired with the instruction.
 struct Annotation {
-  Annotation() : value(-1){};
+  Annotation() : value(-1) {};
 
   // Initializes all fields of the annotation.
   Annotation(std::string name, double value);

--- a/gematria/datasets/exegesis_benchmark_lib_test.cc
+++ b/gematria/datasets/exegesis_benchmark_lib_test.cc
@@ -51,7 +51,7 @@ class ExegesisBenchmarkTest : public testing::Test {
   std::unique_ptr<ExegesisBenchmark> Benchmark;
 
  protected:
-  ExegesisBenchmarkTest() : Benchmark(cantFail(ExegesisBenchmark::create())){};
+  ExegesisBenchmarkTest() : Benchmark(cantFail(ExegesisBenchmark::create())) {};
 
   static void SetUpTestSuite() {
     // LLVM Setup

--- a/gematria/datasets/process_and_filter_bbs_lib_test.cc
+++ b/gematria/datasets/process_and_filter_bbs_lib_test.cc
@@ -53,7 +53,7 @@ class ProcessFilterBBsTest : public testing::Test {
       : LLVMArchSupport(LlvmArchitectureSupport::X86_64()),
         LLVMInstPrinter(LLVMArchSupport->CreateMCInstPrinter(
             InlineAsm::AsmDialect::AD_ATT)),
-        BBProcessor(){};
+        BBProcessor() {};
 
   std::vector<DisassembledInstruction> removeRiskyInstructions(
       std::string_view TextualAssembly, bool FilterMemoryAccessingBlocks) {


### PR DESCRIPTION
This patch bumps the clang-format that we are using to v19 to fix some issues that came up in #288.