### PR TITLE
Add the "manual" tag to the access pattern microbenchmarks.

### DIFF
--- a/gematria/experiments/access_pattern_bm/BUILD.bazel
+++ b/gematria/experiments/access_pattern_bm/BUILD.bazel
@@ -43,6 +43,7 @@ cc_test(
         "linked_list_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS,
+    tags = ["manual"],
     deps = [
         ":linked_list",
         "@com_github_google_benchmark//:benchmark_main",
@@ -71,6 +72,7 @@ cc_test(
         "contiguous_matrix_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS,
+    tags = ["manual"],
     deps = [
         ":contiguous_matrix",
         "@com_github_google_benchmark//:benchmark_main",
@@ -98,6 +100,7 @@ cc_test(
         "vec_of_vec_matrix_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS,
+    tags = ["manual"],
     deps = [
         ":vec_of_vec_matrix",
         "@com_github_google_benchmark//:benchmark_main",
@@ -113,6 +116,7 @@ cc_test(
         "stl_container_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS + FEATURE_OPTS,  # Since templated functions using _mm_clflushopt are defined in the header.
+    tags = ["manual"],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
@@ -131,6 +135,7 @@ cc_test(
         "stl_assoc_container_test.cc",
     ],
     copts = BALANCE_FLUSHING_TIME_OPTS + FEATURE_OPTS,  # Since templated functions using _mm_clflushopt are defined in the header.
+    tags = ["manual"],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",


### PR DESCRIPTION
 * This should stop the microbenchmarks from being invoked by `bazel test ...`.
 * This prevents the `bazel build` CI checks from failing from one of the microbenchmarks timing out.
 * They can still be run individually using their fully qualified names.