### PR TITLE
Fix use after free in annotating importer

### DIFF
--- a/gematria/datasets/annotating_importer.cc
+++ b/gematria/datasets/annotating_importer.cc
@@ -99,8 +99,7 @@ absl::StatusOr<const quipper::PerfDataProto_MMapEvent *>
 AnnotatingImporter::GetMainMapping(
     const llvm::object::ELFObjectFileBase *elf_object,
     const quipper::PerfDataProto *perf_data) {
-  llvm::StringRef file_name =
-      GetBasenameFromPath(elf_object->getFileName());
+  llvm::StringRef file_name = GetBasenameFromPath(elf_object->getFileName());
   // TODO(vbshah): There may be multiple mappings corresponding to the profiled
   // binary. Record and match samples from all of them instead of assuming
   // there is only one and returning after finding it.

--- a/gematria/datasets/annotating_importer.cc
+++ b/gematria/datasets/annotating_importer.cc
@@ -100,7 +100,7 @@ AnnotatingImporter::GetMainMapping(
     const llvm::object::ELFObjectFileBase *elf_object,
     const quipper::PerfDataProto *perf_data) {
   llvm::StringRef file_name =
-      GetBasenameFromPath(elf_object->getFileName().str());
+      GetBasenameFromPath(elf_object->getFileName());
   // TODO(vbshah): There may be multiple mappings corresponding to the profiled
   // binary. Record and match samples from all of them instead of assuming
   // there is only one and returning after finding it.


### PR DESCRIPTION
There is a line in annotating importer that attempts to get the base name of a path from a StringRef. Before this patch, a StringRef was referenced, .str() was called on it, and then it was passed into a function to extract the base name that took in a StringRef and returned a StringRef. Calling .str() caused a temporary string to get created. Given that string is a temporary, it can get deallocated after calling the function to get the basename, resulting in a use after free when the StringRef is referenced later. This patch simply removes the .str() call so that we purely operate with StringRefs to proper backing memory, which fixes the issue.

This fixes the Gematria->Google3 import. Not entirely sure how/why this did not fail in the open.