### PR TITLE
Fix flaky annotation test

### DIFF
--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -144,11 +144,12 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisZeroAddressError) {
 
 TEST_F(FindAccessedAddrsExegesisTest, ExegesisMultipleSameAddressError) {
   // Try and load memory from an address above the current user space address
-  // space ceiling (assuming five level page tables are not enabled) as the
-  // script will currently try and annotate this, but exegesis will fail
-  // to map the address when it attempts to.
+  // space ceiling as the script will currently try and annotate this, but
+  // exegesis will fail to map the address when it attempts to. We use a value
+  // above the virtual address space ceiling when using five level page tables
+  // to prevent test failures on newer platforms.
   auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
-    movabsq $0x0000800000000000, %rax
+    movabsq $0x0100000000000000, %rax
     movq (%rax), %rax
   )asm");
   ASSERT_FALSE(static_cast<bool>(AddrsOrErr));

--- a/gematria/datasets/find_accessed_addrs_exegesis_test.cc
+++ b/gematria/datasets/find_accessed_addrs_exegesis_test.cc
@@ -148,6 +148,8 @@ TEST_F(FindAccessedAddrsExegesisTest, ExegesisMultipleSameAddressError) {
   // exegesis will fail to map the address when it attempts to. We use a value
   // above the virtual address space ceiling when using five level page tables
   // to prevent test failures on newer platforms.
+  // https://docs.kernel.org/5.10/x86/x86_64/mm.html contains information on
+  // the exact virtual address space layout.
   auto AddrsOrErr = FindAccessedAddrsExegesis(R"asm(
     movabsq $0x0100000000000000, %rax
     movq (%rax), %rax


### PR DESCRIPTION
One of the tests in find_accessed_addrs_exegesis_test checks that if we try and annotate the same address multiple times we bail out. It does this by relying on the fact that exegesis does not error out on mmap failures and by trying to annotate a snippet accessing memory above the user space virtual memory ceiling. This is ceiling is higher on newer platforms with five level page tables, so adjust it to be higher than the new ceiling.

https://docs.kernel.org/5.10/x86/x86_64/mm.html