### PR TITLE
Fix deprecated use of createTargetMachine

### DIFF
--- a/gematria/llvm/BUILD.bazel
+++ b/gematria/llvm/BUILD.bazel
@@ -139,6 +139,7 @@ cc_library(
         "@llvm-project//llvm:MCDisassembler",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
+        "@llvm-project//llvm:TargetParser",
     ],
 )
 

--- a/gematria/llvm/llvm_architecture_support.cc
+++ b/gematria/llvm/llvm_architecture_support.cc
@@ -30,6 +30,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/TargetParser/Triple.h"
 
 namespace gematria {
 namespace {
@@ -90,7 +91,7 @@ LlvmArchitectureSupport::LlvmArchitectureSupport(std::string_view llvm_triple,
     : target_(target) {
   llvm::TargetOptions target_options;
   target_machine_.reset(target_->createTargetMachine(
-      /*TT=*/llvm_triple, /*CPU=*/cpu, /*Features=*/cpu_features,
+      /*TT=*/llvm::Triple(llvm_triple), /*CPU=*/cpu, /*Features=*/cpu_features,
       /*Options=*/target_options, /*RM=*/std::nullopt));
 
   mc_context_ = std::make_unique<llvm::MCContext>(


### PR DESCRIPTION
The overload of createTargetMachine that accepts a string version of the triple is deprecated. Switch over to the version that accepts a llvm::Triple directly to avoid using deprecated functionality.