### PR TITLE
Add histogram summaries to `GnnModelBase`.

### DIFF
--- a/gematria/granite/python/gnn_model_base.py
+++ b/gematria/granite/python/gnn_model_base.py
@@ -417,6 +417,15 @@ class GnnModelBase(model_base.ModelBase):
           )
     return graphs_tuple
 
+  def _add_histogram_summaries(self) -> None:
+    """Adds histogram summaries for tensors.
+
+    Logs histograms for all trainable variables within graph layers.
+    """
+    for layer in self._graph_network:
+      for var in layer.module.trainable_variables:
+        tf.summary.histogram(var.name.replace(':', '_'), var)
+
   def _create_readout_network_resources(self) -> None:
     """Creates resources (like TensorFlow ops) needed by the readout network.
 

--- a/gematria/model/python/model_base.py
+++ b/gematria/model/python/model_base.py
@@ -415,6 +415,7 @@ class ModelBase(metaclass=abc.ABCMeta):
       )
     self._create_output_and_loss_tensors()
     self._create_optimizer()
+    self._add_histogram_summaries()
     tf.summary.scalar('learning_rate', self._decayed_learning_rate)
 
   @property
@@ -599,6 +600,15 @@ class ModelBase(metaclass=abc.ABCMeta):
     for task_idx, task_name in enumerate(self._task_list):
       summary_name = f'{error_name}_{task_name}'
       tf.summary.scalar(summary_name, error_tensor[task_idx])
+
+  @abc.abstractmethod
+  def _add_histogram_summaries(self) -> None:
+    """Adds histogram summaries for tensors.
+
+    Adds code for logging histogram summaries for model-specific tensors.
+
+    By default, this method is a no-op.
+    """
 
   def _create_output_and_loss_tensors(self) -> None:
     """Creates the output, expected output and loss tensors.


### PR DESCRIPTION
 * Adds a call to a new abstract method to set up histogram summaries to the model initialization pipeline.
 * Implements this in `GnnModelBase` to log histogram summaries for all of its trainable variables, i.e. those in the graph network layers.