### PR TITLE
Restore TensorBoard summary logging after TF 2 migration.

### DIFF
--- a/gematria/model/python/main_function.py
+++ b/gematria/model/python/main_function.py
@@ -826,8 +826,8 @@ def run_gematria_model_from_command_line_flags(
       )
 
       with train_summary_writer.as_default(), tf.summary.record_if(
-          lambda: tf.math.equal(
-              model.global_step % _GEMATRIA_SAVE_SUMMARIES_EPOCHS, 0
+          lambda: tf.equal(
+              model.global_step % _GEMATRIA_SAVE_SUMMARIES_EPOCHS.value, 0
           )
       ):
         model.train(

--- a/gematria/model/python/model_base.py
+++ b/gematria/model/python/model_base.py
@@ -1294,7 +1294,7 @@ class ModelBase(tf.Module, metaclass=abc.ABCMeta):
         return self.train_batch(schedule)
 
     with timer.scoped('ModelBase.train - one batch', num_iterations=num_epochs):
-      for epoch_index in range(0, num_epochs):
+      for epoch_index in range(num_epochs):
         tf.summary.experimental.set_step(epoch_index)
         stats = run_one_epoch()
         logging.info('Training: %s', stats)


### PR DESCRIPTION
 * Logs most of the previously logged scalars.
 * Bonus: wraps training in `timer.scoped`.