### PR TITLE
Remove tf.compat.v1 imports in io/

### DIFF
--- a/gematria/granite/python/BUILD.bazel
+++ b/gematria/granite/python/BUILD.bazel
@@ -89,6 +89,7 @@ gematria_py_test(
     size = "small",
     timeout = "moderate",
     srcs = ["graph_builder_model_base_test.py"],
+    shard_count = 25,
     deps = [
         ":gnn_model_base",
         ":graph_builder",

--- a/gematria/granite/python/run_granite_model.py
+++ b/gematria/granite/python/run_granite_model.py
@@ -22,7 +22,7 @@ from gematria.model.python import main_function
 from gematria.model.python import options
 from gematria.model.python import token_model_flags
 from gematria.utils.python import flag_utils
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
 
 
 def main(argv):
@@ -109,5 +109,4 @@ def main(argv):
 if __name__ == '__main__':
   token_model_flags.mark_token_flags_as_required()
   token_model_flags.set_default_oov_replacement_token(tokens.UNKNOWN)
-  tf.disable_v2_behavior()
   app.run(main)


### PR DESCRIPTION
The only thing that we needed to keep was the usage of
tf.compat.v1.io.tf_record_iterator that should get removed eventually
when we move over to the actual dataset APIs.
