### PR TITLE
[CI] Replace `chmod` with `chown` in CI Bazel output base setup.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -126,7 +126,8 @@ jobs:
         sudo ln -s /usr/bin/clang-19 /usr/bin/clang && \
         sudo ln -s /usr/bin/clang-19 /usr/bin/clang++
     - name: Setup bazel output base
-      run: sudo mkdir /mnt/output_base && sudo chmod a+rw /mnt/output_base
+      run: |
+        sudo mkdir /mnt/output_base && sudo chown $USER:$USER /mnt/output_base
     - name: Cache Bazel
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
 * The cache action still complains about some permissions after being given write access to output base.
 * This gives the runner user ownership of the output base to stop this.