### PR TITLE
Fix bug encountered while creating model residual layers.

### DIFF
--- a/gematria/granite/python/gnn_model_base.py
+++ b/gematria/granite/python/gnn_model_base.py
@@ -61,6 +61,12 @@ class GraphNetworkLayer(tf.Module):
       features computed by the layer. When both a residual connection and layer
       normalization are used, the layer normalization op is inserted after the
       residual connection.
+    edges_output_size: The size of the final output from this layer's edge model
+      function. Required to be of the form `(None, n)`. 
+    nodes_output_size: The size of the final output from this layer's node model
+      function. Required to be of the form `(None, n)`. 
+    globals_output_size: The size of the final output from this layer's global
+      model function. Required to be of the form `(None, n)`. 
     extra_node_inputs: Names of extra feed_dict members that should be passed
       to the node model.
   """
@@ -230,7 +236,7 @@ class GnnModelBase(model_base.ModelBase):
     self._residual_layers = {}
     nodes_residual_shape = None
     edges_residual_shape = None
-    gloabls_residual_shape = None
+    globals_residual_shape = None
     for layer_index, layer in enumerate(self._graph_network):
       num_iterations = (
           layer.num_iterations or self._num_message_passing_iterations
@@ -256,7 +262,7 @@ class GnnModelBase(model_base.ModelBase):
         if use_residual_connections:
           assert nodes_residual_shape is not None
           assert edges_residual_shape is not None
-          assert gloabls_residual_shape is not None
+          assert globals_residual_shape is not None
           residual_op_name_base = (
               f'residual_connection_{layer_index}_{iteration}'
           )
@@ -277,13 +283,13 @@ class GnnModelBase(model_base.ModelBase):
           )
           self._residual_layers[globals_residual_layer_name] = (
               model_blocks.ResidualConnectionLayer(
-                  (globals_tensor_shape, gloabls_residual_shape),
+                  (globals_tensor_shape, globals_residual_shape),
                   name=globals_residual_layer_name,
               )
           )
         nodes_residual_shape = nodes_tensor_shape
         edges_residual_shape = edges_tensor_shape
-        gloabls_residual_shape = globals_tensor_shape
+        globals_residual_shape = globals_tensor_shape
         if use_layer_norm:
           layer_norm_name_base = (
               f'graph_network_layer_norm_{layer_index}_{iteration}'

--- a/gematria/granite/python/gnn_model_base.py
+++ b/gematria/granite/python/gnn_model_base.py
@@ -62,11 +62,11 @@ class GraphNetworkLayer(tf.Module):
       normalization are used, the layer normalization op is inserted after the
       residual connection.
     edges_output_size: The size of the final output from this layer's edge model
-      function. Required to be of the form `(None, n)`. 
+      function. Required to be of the form `(None, n)`.
     nodes_output_size: The size of the final output from this layer's node model
-      function. Required to be of the form `(None, n)`. 
+      function. Required to be of the form `(None, n)`.
     globals_output_size: The size of the final output from this layer's global
-      model function. Required to be of the form `(None, n)`. 
+      model function. Required to be of the form `(None, n)`.
     extra_node_inputs: Names of extra feed_dict members that should be passed
       to the node model.
   """

--- a/gematria/granite/python/token_graph_builder_model.py
+++ b/gematria/granite/python/token_graph_builder_model.py
@@ -363,6 +363,9 @@ class TokenGraphBuilderModel(graph_builder_model_base.GraphBuilderModelBase):
             num_iterations=1,
             layer_normalization=options.EnableFeature.NEVER,
             residual_connection=options.EnableFeature.NEVER,
+            edges_output_size=(None, self._edge_embedding_size),
+            nodes_output_size=(None, self._node_embedding_size),
+            globals_output_size=(None, self._global_embedding_size),
             extra_node_inputs=(
                 'instruction_node_mask',
                 'instruction_annotations',
@@ -396,6 +399,9 @@ class TokenGraphBuilderModel(graph_builder_model_base.GraphBuilderModelBase):
             num_iterations=None,
             layer_normalization=options.EnableFeature.BY_FLAG,
             residual_connection=options.EnableFeature.BY_FLAG,
+            edges_output_size=(None, self._edge_update_layers[-1]),
+            nodes_output_size=(None, self._node_update_layers[-1]),
+            globals_output_size=(None, self._global_update_layers[-1]),
         ),
     )
 


### PR DESCRIPTION
 * Some attributes required while creating residual layers in `TokenGraphBuilderModel`s were not set during initialization.
 * This could benefit from some further refactoring, but this is the minimal fix to allow models to run.