### PR TITLE
Prevent `tf.function` retracing and minor TF2 fixes.

### DIFF
--- a/gematria/model/python/loss_utils.py
+++ b/gematria/model/python/loss_utils.py
@@ -84,6 +84,7 @@ def _make_percentile_tensor(
   return percentile_tensor
 
 
+@tf.autograph.experimental.do_not_convert
 def _apply_loss_function(
     loss_type: options.LossType,
     normalized_delta: tf.Tensor,
@@ -99,6 +100,7 @@ def _apply_loss_function(
   raise ValueError(f'Unexpected loss type {loss_type!r}')
 
 
+@tf.autograph.experimental.do_not_convert
 def _apply_normalization(
     normalization: options.ErrorNormalization,
     delta: tf.Tensor,

--- a/gematria/model/python/model_base.py
+++ b/gematria/model/python/model_base.py
@@ -1320,7 +1320,7 @@ class ModelBase(tf.Module, metaclass=abc.ABCMeta):
   def compute_loss_tensor(self, schedule: FeedDict):
     return tf.reduce_mean(self._compute_loss(schedule).loss_tensor)
 
-  @tf.function
+  @tf.function(reduce_retracing=True)
   def _compute_and_apply_gradients(
       self, schedule: FeedDict
   ) -> loss_utils.LossComputation:

--- a/gematria/model/python/training.py
+++ b/gematria/model/python/training.py
@@ -174,27 +174,27 @@ class TrainingEpochStats:
   def __str__(self) -> str:
     """Converts the stats to a human-readable string."""
     parts = [
-        f'epoch: {self.epoch.numpy()}, loss: {self.loss}',
+        f'epoch: {_unwrap_if_tensor(self.epoch)}, loss: {self.loss}',
         self._format_loss_string(
             'absolute',
-            self.absolute_mse.numpy(),
+            _unwrap_if_tensor(self.absolute_mse),
             None,
-            self.absolute_error_percentiles.numpy(),
+            _unwrap_if_tensor(self.absolute_error_percentiles),
         ),
         self._format_loss_string(
             'relative',
-            self.relative_mse.numpy(),
-            self.relative_mae.numpy(),
-            self.relative_error_percentiles.numpy(),
+            _unwrap_if_tensor(self.relative_mse),
+            _unwrap_if_tensor(self.relative_mae),
+            _unwrap_if_tensor(self.relative_error_percentiles),
         ),
     ]
     if self.absolute_delta_mse is not None:
       parts.append(
           self._format_loss_string(
               'absolute delta',
-              self.absolute_delta_mse.numpy(),
-              self.absolute_delta_mae.numpy(),
-              self.absolute_delta_error_percentiles.numpy(),
+              _unwrap_if_tensor(self.absolute_delta_mse),
+              _unwrap_if_tensor(self.absolute_delta_mae),
+              _unwrap_if_tensor(self.absolute_delta_error_percentiles),
           )
       )
     return '\n'.join(parts)
@@ -363,3 +363,12 @@ def _as_list(values: Sequence[float]) -> list[float]:
   if isinstance(values, np.ndarray):
     return values.tolist()
   return list(values)
+
+
+def _unwrap_if_tensor(
+    maybe_tensor: tf.Tensor | Sequence[float] | float,
+) -> Sequence[float] | float:
+  """Unwraps `maybe_tensor` if it is a Tensor."""
+  if tf.is_tensor(maybe_tensor):
+    return maybe_tensor.numpy()
+  return maybe_tensor

--- a/gematria/model/python/training.py
+++ b/gematria/model/python/training.py
@@ -174,24 +174,27 @@ class TrainingEpochStats:
   def __str__(self) -> str:
     """Converts the stats to a human-readable string."""
     parts = [
-        f'epoch: {self.epoch}, loss: {self.loss}',
+        f'epoch: {self.epoch.numpy()}, loss: {self.loss}',
         self._format_loss_string(
-            'absolute', self.absolute_mse, None, self.absolute_error_percentiles
+            'absolute',
+            self.absolute_mse.numpy(),
+            None,
+            self.absolute_error_percentiles.numpy(),
         ),
         self._format_loss_string(
             'relative',
-            self.relative_mse,
-            self.relative_mae,
-            self.relative_error_percentiles,
+            self.relative_mse.numpy(),
+            self.relative_mae.numpy(),
+            self.relative_error_percentiles.numpy(),
         ),
     ]
     if self.absolute_delta_mse is not None:
       parts.append(
           self._format_loss_string(
               'absolute delta',
-              self.absolute_delta_mse,
-              self.absolute_delta_mae,
-              self.absolute_delta_error_percentiles,
+              self.absolute_delta_mse.numpy(),
+              self.absolute_delta_mae.numpy(),
+              self.absolute_delta_error_percentiles.numpy(),
           )
       )
     return '\n'.join(parts)


### PR DESCRIPTION
 * The main `tf.function` (`_compute_and_apply_gradients`) was forcing re-traces on every call for some model configurations with a significant performance penalty. Passing `reduce_retracing=True` seems to be enough to prevent this: TF is able to construct a `ConcreteFunction` with the right input signature after seeing a few invocations.
 * Marks model functions using `match-case` as excluded from AutoGraph conversion. AutoGraph fails to convert them anyways, and this suppresses related warnings.
 * Makes `TrainingEpochStats` print correctly as actual values, rather than the enclosing Tensors.