### PR TITLE
Update Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update && \
 apt-get install -y \
     curl \
@@ -8,7 +8,7 @@ apt-get install -y \
     python3 \
     python3-pip \
     gnupg
-RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main\ndeb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" >> /etc/apt/sources.list && \
+RUN echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main\ndeb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" >> /etc/apt/sources.list && \
   curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
   apt-get update && \
@@ -20,5 +20,4 @@ RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk
 WORKDIR /gematria
 COPY . .
 ENV USE_BAZEL_VERSION 7.x
-RUN pip3 install -r requirements.txt
 


### PR DESCRIPTION
This patch makes a couple changes to the container image definition so that it works with recent changes.
* It updates the container image to ubuntu:24.04 which has the default python version of 3.12 so that it matches that quasi-hermetic toolchain setup in bazel. Otherwise we get errors when trying to load pybind modules as they are compiled against 3.12.
* We remove the python package installation requirements due to them now being handled by bazel and the file being used no longer existing.