### PR TITLE
Bump timeout for requirements test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -143,7 +143,4 @@ jobs:
     - name: Run build
       run: bazel --output_base=/mnt/output_base build -c ${{ matrix.build-config }} ...
     - name: Run tests
-      # TODO(vbshah): We exclude `requirements_3_X_test` because its timeout is
-      # too short for it to pass consistently. Re-include it once it is fixed
-      # or `rules_python` is patched to extend the timeout. 
-      run: bazel --output_base=/mnt/output_base test -c ${{ matrix.build-config }} --define run_under_ci=1 --test_tag_filters="-perf_counters" --test_output=errors -- ... -//:requirements_3_12_test
+      run: bazel --output_base=/mnt/output_base test -c ${{ matrix.build-config }} --define run_under_ci=1 --test_tag_filters="-perf_counters" --test_output=errors -- ...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,7 @@ compile_pip_requirements_3_12(
     name = "requirements_3_12",
     src = "requirements.in",
     requirements_txt = "requirements_lock_3_12.txt",
+    timeout = "moderate",
 )
 
 exports_files(["requirements.in"])

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,9 +37,9 @@ copy_file(
 
 compile_pip_requirements_3_12(
     name = "requirements_3_12",
+    timeout = "moderate",
     src = "requirements.in",
     requirements_txt = "requirements_lock_3_12.txt",
-    timeout = "moderate",
 )
 
 exports_files(["requirements.in"])


### PR DESCRIPTION
This test takes a while and times out on quite a few systems (including CI and my sandy bridge desktop). Bump the timeout by adding a timeout option to the rule which passes extra keyword arguments to the underlying test rule.