### PR TITLE
Bump LLVM to a7091951f0bbdeb78a76f933394a7754c5990371

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ name: Gematria CI
 # TODO(virajbshah): Find a better way to keep these two in sync without the
 # need to update one manually every time the other is changed.
 env:
-  LLVM_COMMIT: 88c4ef2f9fc0cda90c8452bc1c46844aaa722a3e
+  LLVM_COMMIT: a7091951f0bbdeb78a76f933394a7754c5990371
 
 on:
   push:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -205,14 +205,14 @@ new_git_repository(
 # The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
 # `.github/workflows/main.yaml` must be updated to match this everytime it is
 # changed.
-LLVM_COMMIT = "88c4ef2f9fc0cda90c8452bc1c46844aaa722a3e"
+LLVM_COMMIT = "a7091951f0bbdeb78a76f933394a7754c5990371"
 
-LLVM_SHA256 = "163cc60d594aebef8a67088c81d56d19ea90d546de5212b5b1edc1ba4abc662c"
+LLVM_INTEGRITY = "sha256-H29TjFVwTcoXSAXhiOwHdPJQWLScB/hWDTcl8Q5HWmg="
 
 http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
-    sha256 = LLVM_SHA256,
+    integrity = LLVM_INTEGRITY,
     strip_prefix = "llvm-project-" + LLVM_COMMIT,
     urls = ["https://github.com/llvm/llvm-project/archive/{commit}.zip".format(commit = LLVM_COMMIT)],
 )

--- a/gematria/llvm/llvm_architecture_support.cc
+++ b/gematria/llvm/llvm_architecture_support.cc
@@ -91,7 +91,8 @@ LlvmArchitectureSupport::LlvmArchitectureSupport(std::string_view llvm_triple,
     : target_(target) {
   llvm::TargetOptions target_options;
   target_machine_.reset(target_->createTargetMachine(
-      /*TT=*/llvm::Triple(llvm_triple), /*CPU=*/cpu, /*Features=*/cpu_features,
+      /*TT=*/llvm::Triple(llvm::Twine(llvm_triple)), /*CPU=*/cpu,
+      /*Features=*/cpu_features,
       /*Options=*/target_options, /*RM=*/std::nullopt));
 
   mc_context_ = std::make_unique<llvm::MCContext>(


### PR DESCRIPTION
This patch bumps LLVM to a7091951f0bbdeb78a76f933394a7754c5990371 and fixes an ambiguous cast that was already fixed internally.

This patch also switches to using the http_archive integrity argument instead of the sha argument for validating the LLVM archive given that is what bazel 7 seems to spit out by default.