### PR TITLE
Bump bazelisk version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main\ndeb-src h
   apt-get install -y clang-19 lld-19 && \
   ln -s /usr/bin/clang-19 /usr/bin/clang && \
   ln -s /usr/bin/clang-19 /usr/bin/clang++
-ARG bazelisk_version=1.19.0
+ARG bazelisk_version=1.26.0
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v${bazelisk_version}/bazelisk-linux-amd64 > /usr/bin/bazelisk && chmod +x /usr/bin/bazelisk && ln -s /usr/bin/bazelisk /usr/bin/bazel
 WORKDIR /gematria
 COPY . .


### PR DESCRIPTION
This patch bumps the bazelisk version in the Dockerfile. No particular reason, but it has not been updated in a while and the newer version works so we might as well bump it.