### PR TITLE
Misc pytype fixes for import

### DIFF
--- a/gematria/granite/python/gnn_model_base.py
+++ b/gematria/granite/python/gnn_model_base.py
@@ -79,9 +79,9 @@ class GraphNetworkLayer(tf.Module):
   num_iterations: Optional[int]
   layer_normalization: options.EnableFeature
   residual_connection: options.EnableFeature
-  edges_output_size: Sequence[int] | None = None
-  nodes_output_size: Sequence[int] | None = None
-  globals_output_size: Sequence[int] | None = None
+  edges_output_size: Sequence[int | None] | None = None
+  nodes_output_size: Sequence[int | None] | None = None
+  globals_output_size: Sequence[int | None] | None = None
   extra_node_inputs: Sequence[str] | None = None
 
 

--- a/gematria/model/python/training.py
+++ b/gematria/model/python/training.py
@@ -366,8 +366,8 @@ def _as_list(values: Sequence[float]) -> list[float]:
 
 
 def _unwrap_if_tensor(
-    maybe_tensor: tf.Tensor | Sequence[float] | float,
-) -> Sequence[float] | float:
+    maybe_tensor: tf.Tensor | Sequence[Sequence[float]] | Sequence[float] | float,
+) -> Sequence[Sequence[float]] | Sequence[float] | float:
   """Unwraps `maybe_tensor` if it is a Tensor."""
   if tf.is_tensor(maybe_tensor):
     return maybe_tensor.numpy()

--- a/gematria/model/python/training.py
+++ b/gematria/model/python/training.py
@@ -366,7 +366,10 @@ def _as_list(values: Sequence[float]) -> list[float]:
 
 
 def _unwrap_if_tensor(
-    maybe_tensor: tf.Tensor | Sequence[Sequence[float]] | Sequence[float] | float,
+    maybe_tensor: tf.Tensor
+    | Sequence[Sequence[float]]
+    | Sequence[float]
+    | float,
 ) -> Sequence[Sequence[float]] | Sequence[float] | float:
   """Unwraps `maybe_tensor` if it is a Tensor."""
   if tf.is_tensor(maybe_tensor):


### PR DESCRIPTION
There are a couple new pytype issues introduced by recent commits. This patch fixes them. Namely the percentiles is expected to be a list of lists rather than just a list and _unwrap_if_tensor does not currently report returning that. We can also have None edge/node/global output sizes in GraphNetworkLayer, so make sure to support that as well.