### PR TITLE
Fix bug in `StrAppendList` for `BasicBlockGraphBuilder::DebugString`.

### DIFF
--- a/gematria/granite/graph_builder.cc
+++ b/gematria/granite/graph_builder.cc
@@ -485,9 +485,10 @@ void StrAppendList(std::stringstream& buffer, std::string_view list_name,
   buffer << list_name << " = [";
   bool first = true;
   for (const auto& item : items) {
-    if (!first) {
-      buffer << ",";
+    if (first) {
       first = false;
+    } else {
+      buffer << ", ";
     }
     buffer << item;
   }


### PR DESCRIPTION
* This fixes a bug in `StrAppendList`, causing commas separating items in the returned list string representation to be missing.