### PR TITLE
Refactor `BasicBlockGraphBuilder::AddBasicBlockFromInstructions`.

### DIFF
--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -360,6 +360,10 @@ class BasicBlockGraphBuilder {
     size_t prev_global_features_size_;
   };
 
+  // Adds nodes and edges for a single instruction of a basic block.
+  NodeIndex AddInstruction(const Instruction& instruction,
+                           NodeIndex previous_instruction_node);
+
   // Adds nodes and edges for a single input operand of an instruction.
   bool AddInputOperand(NodeIndex instruction_node,
                        const InstructionOperand& operand);

--- a/gematria/granite/python/graph_builder.cc
+++ b/gematria/granite/python/graph_builder.cc
@@ -14,13 +14,11 @@
 
 #include "gematria/granite/graph_builder.h"
 
-#include <set>
 #include <string>
 #include <vector>
 
 #include "absl/strings/string_view.h"
 #include "gematria/model/oov_token_behavior.h"
-#include "gematria/proto/canonicalized_instruction.pb.h"
 #include "pybind11/cast.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"


### PR DESCRIPTION
 * Factor out the per-instruction add to graph logic.
 * This change is in preparation for further changes to the graph construction logic.
 * Specifically, this should make the trace graph construction code cleaner.