### PR TITLE
Refactor graph builder instruction annotations processing.

### DIFF
--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -360,6 +360,10 @@ class BasicBlockGraphBuilder {
     size_t prev_global_features_size_;
   };
 
+  // Adds nodes and edges for a single instruction of a basic block.
+  NodeIndex AddInstruction(const Instruction& instruction,
+                           NodeIndex previous_instruction_node);
+
   // Adds nodes and edges for a single input operand of an instruction.
   bool AddInputOperand(NodeIndex instruction_node,
                        const InstructionOperand& operand);

--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -91,7 +91,6 @@
 
 #include <cstddef>
 #include <ostream>
-#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -386,6 +385,10 @@ class BasicBlockGraphBuilder {
   NodeIndex AddNode(NodeType node_type, const std::string& token);
   // Adds a new edge to the batch.
   void AddEdge(EdgeType edge_type, NodeIndex sender, NodeIndex receiver);
+
+  // Updates the `instruction_annotations_` tensor with annotations from
+  // `instruction`.
+  void AddInstructionAnnotations(const Instruction& instruction);
 
   // Mapping from string node tokens to indices of embedding vectors used in
   // the models.

--- a/gematria/granite/python/graph_builder.cc
+++ b/gematria/granite/python/graph_builder.cc
@@ -14,13 +14,11 @@
 
 #include "gematria/granite/graph_builder.h"
 
-#include <set>
 #include <string>
 #include <vector>
 
 #include "absl/strings/string_view.h"
 #include "gematria/model/oov_token_behavior.h"
-#include "gematria/proto/canonicalized_instruction.pb.h"
 #include "pybind11/cast.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"


### PR DESCRIPTION
 * Move annotation adding logic to `AddInstructionAnnotations`.
 * Remove default annotation magic number.