### PR TITLE
Store instruction annotation values as C++ `double`s.

### DIFF
--- a/gematria/granite/graph_builder.cc
+++ b/gematria/granite/graph_builder.cc
@@ -34,7 +34,7 @@ namespace {
 
 constexpr BasicBlockGraphBuilder::NodeIndex kInvalidNode(-1);
 constexpr BasicBlockGraphBuilder::TokenIndex kInvalidTokenIndex(-1);
-constexpr float kDefaultInstructionAnnotation(-1);
+constexpr double kDefaultInstructionAnnotation(-1);
 
 std::unordered_map<std::string, BasicBlockGraphBuilder::TokenIndex> MakeIndex(
     std::vector<std::string> items) {
@@ -173,7 +173,7 @@ BasicBlockGraphBuilder::BasicBlockGraphBuilder(
               : FindTokenOrDie(
                     node_tokens_,
                     out_of_vocabulary_behavior.replacement_token())) {
-  instruction_annotations_ = std::vector<std::vector<float>>();
+  instruction_annotations_ = std::vector<std::vector<double>>();
 
   // Make sure annotations are stored in a stable order as long the same
   // annotation names are used.
@@ -449,8 +449,8 @@ void BasicBlockGraphBuilder::AddInstructionAnnotations(
     const Instruction& instruction) {
   // Store the annotations for later use, using `kDefaultInstructionAnnotation`
   // as a default value wherever annotations are missing.
-  std::vector<float> row = std::vector<float>(annotation_names_.size(),
-                                              kDefaultInstructionAnnotation);
+  std::vector<double> row = std::vector<double>(annotation_names_.size(),
+                                                kDefaultInstructionAnnotation);
   for (const auto& [name, value] : instruction.instruction_annotations) {
     const auto annotation_index = annotation_name_to_idx_.find(name);
     if (annotation_index == annotation_name_to_idx_.end()) continue;

--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -250,7 +250,7 @@ class BasicBlockGraphBuilder {
   // `num_instructions` x `annotation_names.size()` matrix, each entry of which
   // represents the value of the annotation of the type corresponding to the
   // column for the instruction corresponding to the row.
-  const std::vector<std::vector<float>>& instruction_annotations() const {
+  const std::vector<std::vector<double>>& instruction_annotations() const {
     return instruction_annotations_;
   }
 
@@ -417,7 +417,7 @@ class BasicBlockGraphBuilder {
   // Mapping from annotation type names to corresponding row index in the
   // `instruction_annotations_` matrix.
   std::unordered_map<std::string, int> annotation_name_to_idx_;
-  std::vector<std::vector<float>> instruction_annotations_;
+  std::vector<std::vector<double>> instruction_annotations_;
 
   std::vector<NodeIndex> edge_senders_;
   std::vector<NodeIndex> edge_receivers_;

--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -360,6 +360,10 @@ class BasicBlockGraphBuilder {
     size_t prev_global_features_size_;
   };
 
+  // Adds nodes and edges for a single instruction of a basic block.
+  NodeIndex AddInstruction(const Instruction& instruction,
+                           NodeIndex previous_instruction_node);
+
   // Adds nodes and edges for a single input operand of an instruction.
   bool AddInputOperand(NodeIndex instruction_node,
                        const InstructionOperand& operand);

--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -91,7 +91,6 @@
 
 #include <cstddef>
 #include <ostream>
-#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -386,6 +385,10 @@ class BasicBlockGraphBuilder {
   NodeIndex AddNode(NodeType node_type, const std::string& token);
   // Adds a new edge to the batch.
   void AddEdge(EdgeType edge_type, NodeIndex sender, NodeIndex receiver);
+
+  // Updates the `instruction_annotations_` tensor with annotations from
+  // `instruction`.
+  void AddInstructionAnnotations(const Instruction& instruction);
 
   // Mapping from string node tokens to indices of embedding vectors used in
   // the models.

--- a/gematria/granite/graph_builder_model_inference.cc
+++ b/gematria/granite/graph_builder_model_inference.cc
@@ -305,7 +305,7 @@ llvm::Error FillTensorFromStdVectorMatrix(
   auto* const tensor_data =
       interpreter->typed_input_tensor<TensorElementType>(tensor_index);
   for (int row = 0; row < input_matrix.size(); ++row) {
-    const std::vector<TensorElementType>& row_data = input_matrix[row];
+    const std::vector<InputElementType>& row_data = input_matrix[row];
     if (expected_size != row_data.size()) {
       return llvm::createStringError(
           llvm::errc::invalid_argument,
@@ -676,7 +676,7 @@ GraphBuilderModelInference::RunInference() {
 
   const std::vector<bool> instruction_node_mask =
       graph_builder_->InstructionNodeMask();
-  const std::vector<std::vector<float>>& instruction_annotations =
+  const std::vector<std::vector<double>>& instruction_annotations =
       graph_builder_->instruction_annotations();
   const std::vector<int> delta_block_index = graph_builder_->DeltaBlockIndex();
 

--- a/gematria/granite/python/graph_builder.cc
+++ b/gematria/granite/python/graph_builder.cc
@@ -14,13 +14,11 @@
 
 #include "gematria/granite/graph_builder.h"
 
-#include <set>
 #include <string>
 #include <vector>
 
 #include "absl/strings/string_view.h"
 #include "gematria/model/oov_token_behavior.h"
-#include "gematria/proto/canonicalized_instruction.pb.h"
 #include "pybind11/cast.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/pybind11.h"


### PR DESCRIPTION
 * Instruction annotations are currently stored as `float`s in the C++ graph builder.
 * This matches the type currently used by the models (`tf.dtypes.float32`), but not the proto storage type (`double`).
 * For consistency, store annotations as `double`s at the C++ end, then narrow down to the type the models use.