### PR TITLE
Bump LLVM to 0df365180

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ name: Gematria CI
 # TODO(virajbshah): Find a better way to keep these two in sync without the
 # need to update one manually every time the other is changed.
 env:
-  LLVM_COMMIT: a7091951f0bbdeb78a76f933394a7754c5990371
+  LLVM_COMMIT: 0df3651802d35b26ae857b549de9edf73b67fb98
 
 on:
   push:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -205,9 +205,9 @@ new_git_repository(
 # The pinned version of LLVM, and its SHA256 hash. The `LLVM_COMMIT` variable in
 # `.github/workflows/main.yaml` must be updated to match this everytime it is
 # changed.
-LLVM_COMMIT = "a7091951f0bbdeb78a76f933394a7754c5990371"
+LLVM_COMMIT = "0df3651802d35b26ae857b549de9edf73b67fb98"
 
-LLVM_INTEGRITY = "sha256-H29TjFVwTcoXSAXhiOwHdPJQWLScB/hWDTcl8Q5HWmg="
+LLVM_INTEGRITY = "sha256-UfqpYHb4c+xdMer9tKeiiRasdoQE2Rbx6sIBnbW+brk="
 
 http_archive(
     name = "llvm-raw",

--- a/gematria/llvm/asm_parser.cc
+++ b/gematria/llvm/asm_parser.cc
@@ -77,7 +77,7 @@ class MCInstStreamer : public llvm::MCStreamer {
     return false;
   }
   void emitValueToAlignment(llvm::Align alignment, int64_t value,
-                            unsigned value_size,
+                            uint8_t value_size,
                             unsigned max_bytes_to_emit) override {}
   void emitZerofill(llvm::MCSection* section, llvm::MCSymbol* symbol,
                     uint64_t size, llvm::Align byte_alignment,


### PR DESCRIPTION
This patch bumps LLVM to 0df365180 and fixes one section asm_parser.cc
to work with the new LLVM version.
